### PR TITLE
KeyedList — pure-platform keyed list custom element (design + first impl)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,19 +5,20 @@
 Valhalla tests double as **dev examples for LLMs** — the audience is the
 model, so optimize for corpus clarity over human editor ergonomics.
 
-- **Let vitest generate snapshot values.** Write
-  `expect(html).toMatchInlineSnapshot()` and run `vitest -u`; never
-  hand-type the HTML. The snapshot is generated truth from real output.
-- **No `/* HTML */` directive.** It only buys editor syntax-highlighting
-  for humans — nothing for an LLM, where the value is self-evidently HTML.
-  It also triggers a vitest inline-snapshot updater bug (a greedy
-  comment-skip coalesces multiple snapshots in one file onto the last on
-  `-u`) and churns the call onto two lines. Use plain single-line
-  `toMatchInlineSnapshot(`"…"`)`.
+- **Generate the value, never hand-type it.** Write
+  `expect(html).toMatchInlineSnapshot()` and run `vitest -u` — the value is
+  generated truth from real output.
+- **Then freeze it to `.toBe('…')` for the committed form.** The vitest `-u`
+  updater coalesces multiple snapshots in one file (writes several onto one
+  call, leaves the others empty) — **NOT fixed in the installed vitest (4.x)**,
+  despite the upstream PR; any adjacent `//` comment or a second snapshot can
+  trigger it. So generate with `toMatchInlineSnapshot`, then convert each to
+  `expect(html).toBe('…')` using the generated string. `.toBe` is immune to the
+  `-u` mangling, reads just as clearly, and is exact string equality for an
+  `outerHTML` string. (Tradeoff: you lose one-step regeneration — to re-gen,
+  temporarily switch back to `toMatchInlineSnapshot`. The real vitest fix is
+  deferred.)
+- **No `/* HTML */` directive** — nothing for an LLM (the value is self-
+  evidently HTML), and it's another `-u` trigger.
 - **Keep JSX inline (single-line)** in tests so HTML snapshots don't pick
   up whitespace text nodes between sibling elements.
-
-Background: the greedy-comment-skip bug is fixed upstream by the vitest PR
-that came out of this repo's work (`fix(snapshot): make inline comment-skip
-regex non-greedy`). Dropping the marker makes our snapshots
-regeneration-safe regardless of which vitest version is installed.

--- a/TODO.md
+++ b/TODO.md
@@ -13,6 +13,31 @@ Related blocks decision: KeyedBlock renames to **ListBlock**
 (js-framework-benchmark holdover name). AnchorBlock remains a cut
 candidate; Toggle TBD.
 
+### ListBlock design — settled 2026-06-17
+
+Two list strategies, distinguished by *node lifecycle* (not by "store
+per-item state or not" — the per-row bound closure is unavoidable; what's
+shared is the one `makeBind` factory = the single render path):
+
+1. **Node-per-item, keyed (THE primary, ~95% of lists).** A rerenderer per
+   row, keyed by id — "swap a rerenderer in per row." Reuses the existing
+   rerenderer wholesale; no new core mechanism. Update/remove/swap/select
+   by key. Most lists are 20–few-hundred rows. Migrating here is what lets
+   the legacy Controller/Updater + injectable/getBound relocate-path in
+   renderer.js be deleted.
+   - Optional cap: recycle a bounded pool of on-hand nodes (paging /
+     keep-N-around) — still interp 1, just with a ceiling. Not virtualization.
+2. **Recycled pool / virtualization (large lists, FUTURE, separate block).**
+   K nodes ≪ N items; rebind the pool to a data window on scroll. Different
+   node lifecycle, so a distinct block — not a mode toggle on ListBlock.
+   Paint-dodge for offscreen rows: `content-visibility` (modern form of the
+   old `display`-hidden trick).
+
+Implementation increment when picked up: rewrite KeyedBlock → ListBlock as a
+`Map<key, rerenderer(rowFn)>` over the shared row template; then remove the
+now-unused Controller/Updater/getBound legacy path; then block tests
+(js-framework-benchmark-style add/update/swap/remove/select).
+
 ## Attribute vs property table (2.0 release-gating)
 
 Azoth currently does nothing here — WYSIWYG. Static JSX values compile

--- a/docs/design/VirtualList.md
+++ b/docs/design/VirtualList.md
@@ -1,0 +1,39 @@
+# VirtualList (name TBD) — recycled-pool / virtualized list
+
+> Status: FUTURE, separate block. Notes parked while designing
+> [KeyedList](../../packages/maya/blocks/KeyedList.js). Not started.
+
+The second list strategy from the 2026-06-17 TODO decision. Distinguished
+from `KeyedList` by **node lifecycle**, not by a config flag — so it's a
+*distinct block*, not a mode toggle on KeyedList.
+
+## The shape
+
+- **K nodes ≪ N items.** Keep a bounded pool of K row nodes; rebind that
+  pool to a data *window* as the user scrolls. N can be huge; the DOM only
+  ever holds ~K rows.
+- **Paint-dodge for offscreen rows:** `content-visibility` (the modern,
+  honest form of the old `display:none` / offscreen trick).
+
+## Why it keys differently from KeyedList
+
+This is where the two blocks genuinely diverge, and it justifies the split:
+
+- **KeyedList keeps per-row JS state** (a rerenderer per row), so identity
+  lives in JS — a `Map<key, …>`. Location is O(1) in memory; the block
+  never reads the DOM. (The "#1 — key from data" decision.)
+- **VirtualList has no per-row JS state** — the pool *is* the state, and a
+  pooled node's identity changes every time it's rebound to a new data row.
+  Here the DOM genuinely *is* the source of truth, so querying it (the
+  "#2 — key from markup" approach) is the *right* tool, not a round-trip.
+
+So the keying argument we rejected for KeyedList is exactly the one that
+belongs here. Document-as-source-of-truth shines when there's no JS state
+to hold; that's this block, not the primary one.
+
+## Open questions (when picked up)
+
+- Scroll → window mapping: fixed row height (cheap) vs measured/variable.
+- Pool sizing: K = viewport rows + overscan margin; how much overscan.
+- Does it share KeyedList's `map` (row render fn) contract, or its own?
+- Name. `VirtualList`? `WindowedList`? `RecycledList`? TBD.

--- a/docs/design/keyed-list-transcript.md
+++ b/docs/design/keyed-list-transcript.md
@@ -1,0 +1,585 @@
+# KeyedList — design dialogue transcript
+
+_A human–AI design collaboration between **Marty** and **Claude**, working out a `KeyedList` web-component primitive for the Azoth framework. Extracted verbatim from the session transcript; assistant reasoning (“thinking”) blocks were encrypted in the source and are not recoverable, so only the spoken replies appear below._
+
+---
+
+
+## Marty
+
+Keen insights. Let’s keep discussing. I’ll keep
+Poking on the shapes I see., so do you. Riffing. Channel and Rerenderer materialized and and sharpened through exactly this type of discussion and collaboration. 
+
+CSS as correct view logic engine. This is a shift not just of preference but of necessity for azoth’s platform focus. The use of ‘data-selected’ directly tracks to “local state” stored in the DOM. State management allowed lazy thinking. Writing the decision to the document. There is no need in state management to be precise. 
+
+We haven’t touched on KeyedLists actual implementation of DOM manipulation. We developed the UIComponent as init, render, update. KeyedList could or must (?) implement that, but it would effect the map or id, but List doesn’t have a source like channel does. It presents an interface to be controlled by some author defined process. Quick mention that we’ve been dancing around the single node required to work with rerenderer, largely because Fragment disgorges its children on append. Isn’t there a proposal for a durable container? Likewise the inclusion of the container parameter was a hack to avoid the anchoring issues. AnchorBlock showed the compose functionality could be reused. But that tracking mechanism doesn’t work well for arbitrary insertion and removal. I have some ideas but let me get your take.
+
+
+## Claude
+
+Three fat threads here. Let me ground one thing first (the `init/render/update` lifecycle — I want to riff on what's actually there, not a paraphrase) and then give you my takes.
+
+_(searched the codebase for UIComponent / lifecycle init|render|update)_
+
+Lifecycle grounded: the protocol is **intake** (constructor / `initialize(props)`), **`render()`** (no-args first paint), **`update(newProps)`** (change verb). Channel skips `render()` — it has `initial` + a source. That distinction is the hinge for your KeyedList question, so let me start there.
+
+## Riff 1 — KeyedList keeps the delta; that's why it's a controller, not a source
+
+You said it precisely: "List doesn't have a source like channel does. It presents an interface to be controlled by some author defined process." Three intake shapes, not one:
+
+- **Channel** — *push-driven*. The source ticks; update fires internally. The author doesn't call it.
+- **UIComponent** — *prop-driven*. The parent re-renders, hands down `newProps`, `update(newProps)` rebinds.
+- **KeyedList** — *author-driven*. `add` / `move` / `remove` fire on the author's schedule. Nobody pushes; nobody re-renders it from above.
+
+Now connect that to your state-management riff, because they're the same insight. The keyed reconciler — `update(newRowArray)`, diff by key, figure out what moved — **exists only to recover deltas that state management threw away.** You had "user dragged row 3 to slot 0." State management discards that and hands the framework a fresh array; the framework burns a diff to *reconstruct* the delta it was handed for free. That's the lazy blob, paid for downstream.
+
+KeyedList's verb API **keeps the delta.** `move(key, 0)` *is* the fact, stated precisely, no diff. So:
+
+- **`render()`** — yes, it implements this (mount the container, paint initial rows). This is its compose citizenship.
+- **The verbs** (`add`/`update`/`remove`/`move`) — the *primitive* surface. Precise, delta-native, no reconciliation.
+- **`update(rows)`** — *optional, derived* reconcile face, implemented **in terms of** the verbs (diff incoming array against the Map, call add/remove/move). Offer it only as a bridge for authors who genuinely have a blob (it came off the wire as a full array). It's the lazy door, built on the precise machine — not the other way around.
+
+So KeyedList "implements the protocol" at `render()`, declines the single `update(newProps)` (its update is plural and externally clocked), and exposes verbs instead. The reconciler is sugar, and naming it as sugar keeps the precision honest — same move as `data-selected` over a state flag.
+
+## Riff 2 — the durable container already exists; it's an element
+
+Here's where I'll push back on your own framing. You called the `container` param "a hack to avoid the anchoring issues." I think the **mechanism was right and only the justification was a hack.**
+
+A list is a contiguous run of siblings. The DOM already has a durable, mutation-stable container for exactly that: **an element** (`<ul>`, `<ol>`, `<tbody>`, `<menu>`). A `DocumentFragment` disgorges its children on insert *because it's the transient counterpart* — it's a transport, not a home. Reaching for a "durable fragment" is reaching for an element with the serial numbers filed off.
+
+Once the list owns a real parent element, arbitrary manipulation is **native and O(1)**, no anchors:
+
+```
+insert at i   parent.insertBefore(node, parent.children[i])
+move          parent.insertBefore(existingNode, ref)   // relocates in place
+remove        node.remove()
+```
+
+…and the `Map<key, node>` you already hold *is* the ref table. That's the whole DOM-manipulation story. Anchors (the AnchorBlock single comment) only earn their keep when there's **no dedicated parent** — a wrapperless group sharing a parent with foreign siblings. A single anchor gives you "append/replace relative to one point," which is exactly why it **breaks on arbitrary insert/move**, as you observed. Your own evidence argues against the no-container decision from last session: it steers toward anchors, and anchors can't do the thing a list needs.
+
+Bonus payoff — this also resolves the **single-node-for-the-rerenderer** tension you flagged, at both levels:
+- a **row** is a single element → satisfies the rerenderer's unit;
+- the **list** returns its **container element** from `render()` → one node to compose, even though it holds N rows inside.
+
+The fragment problem never arises for a list. It's dodged at the row level (single-root rows) and the list level (element wrapper).
+
+So the real question isn't anchors-vs-param — it's **who instantiates the element:**
+
+| | Author provides it (`into: ul`) | List mints it |
+|---|---|---|
+| Tag semantics (ul/ol/tbody/menu) | author's call ✓ | list must guess or be told |
+| ARIA / class / attrs | author owns ✓ | needs a props story |
+| JSX ergonomics | `<ul>{list.render()}</ul>`-ish | `<KeyedList/>` self-contained |
+
+My lean: **author owns the element, list owns the ordered children.** Tag and ARIA are semantic and belong to the author; the DOM ops are identical either way. That's a clean ownership split, and it rehabilitates the param as *correct*, not hacky. (A middle option: compose `<ul><KeyedList/></ul>` and have the list capture `parentNode` at mount — pretty in JSX, but only clean when the list owns *all* of the parent's children. Worth weighing.)
+
+## On "isn't there a proposal for a durable container?"
+
+Honestly — for the *wrapperless* group case (not lists), the real options are:
+- **`DocumentFragment`** — empties on insert, by spec. Transient by design.
+- **live `Range`** — can bound and manipulate a span of nodes between two points. Real, but heavyweight and it mutates as the DOM mutates.
+- **DOM Parts / Template Instantiation** (web-components CG) — `ChildNodePart`, a marker-bounded child range that supports replacement. Closest thing to a "durable node-range container" — but a *proposal*, not shipped, and I'd want to verify its current state before leaning on it.
+
+I'm not aware of a shipped "persistent fragment that doesn't empty" — flagging that as my belief, not certainty. But the punchline: **a list doesn't need any of it.** That machinery is for the genuinely-wrapperless multi-root case. Lists have a natural element home; use it.
+
+---
+
+That's my take: KeyedList is an author-driven controller whose verbs keep the delta, mounting via `render()` of an element it manages; the container "param" deserves rehabilitation as the durable parent, not anchors. Now — what are your ideas? I'm especially curious whether you're circling paired start/end markers (anchors-done-right), a durable-fragment abstraction, or the element-ownership line — because I think the element line quietly retires the other two for this component.
+
+
+## Marty
+
+It doesn’t make sense for List to implement UIComponent. We need a primitive (maybe two). Simplest is a Class that is not UIComponent gets instantiated and manages itself. We’re groping for a container. Is there a new interface built around how the list gets rendered. In either case The author complies through existing html semantics. In state management you use the same mechanism for both “here’s a series of headers or tabs to render” and “here’s a row changing list”. The former runs render once more often than not. Forward only is easy to write and reason about. Often large part overall app . In azoth that falls under using one time map operations during initial render. Lots of easy render functions. KeyedList is not a state management concept. It’s enhanced row ordering, updating, add remove move. Over known and existing platform list semantics.  crystallized into jsx and surround js. Simple controllers bringing between source interfaces and list operations. Probably good target for encapsulation, e.g. supabase list, our protocol over websocket list, redux todo list, over existing distributed data choices. 
+
+There are no general problem solutions in azoth because there are no general problems. That got removed. Subtract to unlock. 
+
+Also see similarities with web components. Especially that possible interface around dom container semantics. But List is above semantics of jsx. The expression of a particular list. Need to explore if that element property
+
+
+## Claude
+
+Yes — and I'll retract part of my last turn while I'm at it. The durable-fragment / `Range` / DOM-Parts detour was me importing a general problem. "No general problems, subtract to unlock" cuts it cleanly: a list's container isn't a general node-range problem, it's a specific element. I was solving a problem azoth already deleted. Good correction.
+
+Let me riff on the threads you opened.
+
+## The subtraction is static-vs-dynamic, and state management refuses to make it
+
+This is the crux of "same mechanism for both." State management has one hammer — store + reconciler — so **"render these tabs"** and **"this row list is mutating"** both go through diffing machinery. They're not the same problem:
+
+- **"A series of headers / tabs / a render-once list"** — forward-only, no identity tracking, no mutation. In azoth this is just `{items.map(row)}` at initial render. A plain easy render function. As you say — *often a large part of the whole app.* It needs **nothing**. No keys, no controller, no reconciler.
+- **"A row-changing list"** — add/remove/move/update over time. The specialty. This is KeyedList.
+
+State management can't tell these apart because it threw away the distinction up front (everything's "state, re-render, diff"). Azoth keeps the distinction by **subtracting the universal reconciler** — and the moment you remove it, the general problem evaporates: 95% of "lists" are a one-time map, and the remaining 5% *keep their delta* (a controller op), so nobody ever needs to reconstruct-by-diff. The reconciler existed only to recover deltas state management discarded. Remove the discarding, remove the reconciler. That's the unlock.
+
+So KeyedList is **not a list-rendering abstraction.** It's the narrow mutating-list specialty. Most lists never become one.
+
+## KeyedList = a source→list-ops controller; the named adapters are the product
+
+"Simple controllers bringing between source interfaces and list operations" — this is the shape, and it's strong. The base `KeyedList` is the **list-ops primitive** (add/remove/move/update over keyed platform rows). The things people actually *use* are thin source adapters encapsulated on top:
+
+```
+SupabaseList   — realtime row events → list ops
+ProtocolList   — your websocket protocol's deltas → list ops
+TodoList       — a redux/store slice → list ops
+```
+
+Each is "this specific distributed-data choice, wired to platform list semantics." That's the encapsulation boundary, and it's *per-source*, not general — which is exactly right. There's no "universal list." There's "Supabase's list, expressed." The delta-keeping pays off here: a Supabase `UPDATE` event already says *which row, what changed* — the adapter calls `update(key, data)` directly. No diff. The source's delta maps straight to a list op. That's the whole reason this is clean and a reconciler-based list is not.
+
+## The new interface: it *owns* an element, it doesn't *return* a composable
+
+Here's the interface I think you're groping for. UIComponent's contract is **return a composable; the parent may recompose you.** That's wrong for a list. A list's contract is:
+
+> **composed once for placement, then owns its element's children and mutates them directly.**
+
+`render()` exists only to hand its element to JSX for initial drop-in. After that, compose never touches it again — the list self-manages via ops. It *leaves the recompose protocol* the instant it mounts. That's the web-components parallel you're sensing: a custom element is created, connected, and thereafter **owns its subtree** — nobody re-renders it from above; it mutates itself. Same lifecycle shape, minus the recompose contract.
+
+So the "interface around how the list gets rendered" is an **attach-and-own** interface, not a **render-and-recompose** one. And the container is exactly that: **an element property of the controller.** The list *has* an element it owns.
+
+## The fork you trailed off on — "if that element property"
+
+Web components give two ways to be element-bound, and this is the real choice:
+
+- **IS an element** — `class KeyedList extends HTMLElement` → `<keyed-list>`. Unifies controller + element (very WC). But a `<keyed-list>` *isn't* a `<ul>` — you lose platform list semantics (ARIA, list styling, `<tbody>` table participation). The only fix is customized built-ins (`<ul is="keyed-list">`), and those never shipped in Safari. Fragile, and it fights "the author complies through existing HTML semantics."
+- **HAS an element** — plain controller object, `this.element` is a real `<ul>`/`<tbody>` the author authored in JSX and handed over (or the list captured at mount). Controller stays above the markup; the element keeps full platform semantics; ops run native against it.
+
+My call: **HAS.** The author writes the real semantic element in JSX (`<ul role=…>`), the list owns its children. "List is above the semantics of the JSX" — yes, so don't *make* the list an element; let it **point at** one. The element is a property; the controller is the orchestration altitude; the rows are the markup altitude. Three clean layers, no customized-built-in fragility, full HTML semantics preserved.
+
+## On "a primitive, maybe two"
+
+My hypothesis for the two, if it *is* two:
+
+1. **An element-owning region** — the generic "I own this element's children, here are the ordered-mutation ops (insert/move/remove against a parent + a node map)." Source-agnostic, key-agnostic. Pure DOM-ownership.
+2. **KeyedList** — keying + the row rerenderer + `map`/`key`, layered on (1).
+
+That split would let the ownership mechanism be reused by non-keyed cases, with KeyedList as the keyed specialization. But it might be one primitive if nothing else ever needs (1) alone — and per "no general problems," I wouldn't extract (1) until a second real consumer shows up. Subtract until something forces the seam.
+
+So: which way on **has-vs-is** matches what you're seeing — and is the second primitive real to you yet, or are you also feeling it as one self-managing class until proven otherwise?
+
+
+## Marty
+
+Yes! That’s the headline around state managements. Hypermedia is lineage and architecture.  Your framing clearly lays out why static-dynamic matches what actual happens and spells out the thing that’s been in the way the whole time. 
+
+Azoth is JSX for the web platform. Observables and async iter helpers are coming. Azoth fills gaps looking to remove them a missing platform pieces. Its end game has to be to be the progenitor of web standard JSX. Not “react shipped in the browser”, not signals or any state driven paradigm. Not an expanded tagged template syntax. Not an invented syntax (sorry svelte), because JSX earned that.
+
+routes to go I can see:
+
+The has syntax has merit. It fills the gap left by safaris non implementation of is. It gives a reasonable and consistent view of child nodes as default sync content. What does the actual experience look like? An object literal? A component that implements List? But throws otherwise? Introduce attribute as API for intrinsic elements, that’s new surface area. 
+
+Stick with List and have it take two JSX props. Straight jsx “here is my container” works, but where to slot in the jsx seems weak because you have to have a rule like outer element is kept and its children are discarded. 
+
+Take a closer look at web components and ask how azoth and jsx makes that experience better.  `class KeyedList extends HTMLElement → <keyed-list>` doesn’t look like ul or table where it’s placed, but authoring occurs in class MyList extends KeyedList. That’s where root gets created. That’s where li gets created. (Are the acceptable list parents finite? Is it (sketch)  KeyedUnorderedList KeyedOrderedList KeyedTable keyed-ul keyed-li keyed-table?
+But that breaks the stronger supabase list encapsulation) Which strengthens the case for creation in KeyedList. You see the container and the children.
+
+And you get shadow dom. And there very well are other list implementations built around web components. 
+
+Remind me about  are the creation and mounting semantics of web components? How does the initial render and update case express itself? Remounting?
+
+
+## Claude
+
+"Progenitor of web standard JSX" reframes the entire design test. Every choice now asks: **would the platform standardize this?** Not "is it clever," but "is this the shape a web standard would take." Run the three routes through that filter and they sort themselves:
+
+- **Route A (attribute-as-API on intrinsics, `<ul az-list={…}>`)** — you named the cost: new surface area. It's *invented convention on platform elements*. Fails the test — that's the htmx-ish road, not the standards road. Out.
+- **Route B (container as a JSX prop, outer-kept/children-discarded)** — the discard rule is pure subtext. No standard would say "pass an element, I'll keep the shell and throw the contents." It reads as a hack because it is one. Out.
+- **Route C (custom element)** — this one *is* the platform primitive for "an element that owns its subtree and self-manages." It doesn't fail the test; it's the answer the test is pointing at. **This is the line.**
+
+And it answers your earlier "how do azoth + JSX make web components *better*?" Web component authoring is miserable: manual DOM in `connectedCallback`, template-cloning, `attributeChangedCallback` string-juggling, imperative child wrangling. JSX makes the *inside* of the element declarative — `map` is the row template, the rerenderer is the precise update, the custom element is the platform-native ownership shell. **JSX is the missing authoring layer for custom elements.** That's squarely "JSX for the web platform."
+
+So let me give you the lifecycle precisely, since that's what the design rides on.
+
+## Web component creation & mounting
+
+**Creation — `constructor()`**
+Runs when the element is *created*: parser upgrade, `document.createElement`, `new`, or — importantly — at `customElements.define()` time for matching elements *already in the DOM* (**upgrade**). Constraints that shape design: you may **not** touch attributes or children here (the parser may not have set them yet), and you may not add children. You *can* `attachShadow`. Rule of thumb: constructor sets up JS state only; DOM work waits.
+
+**Mounting — `connectedCallback()`**
+Fires **every time** the element is inserted into a document. This is the mount hook, and "every time" is the catch — it can fire repeatedly, so initial render is guarded by a `#rendered` flag. This is where you build the subtree (light or shadow).
+
+**Unmount — `disconnectedCallback()`**
+Fires on every removal. Cleanup, listener teardown.
+
+**Cross-document — `adoptedCallback()`** (rare; `adoptNode` into another document).
+
+**Update — `attributeChangedCallback(name, old, new)` + `static observedAttributes`**
+The declarative change channel — but **string attributes only**. Rich JS data comes through **property setters** you write, which trigger your own re-render. There is no built-in re-render; you wire the update path yourself.
+
+## How initial-render vs update vs remount express
+
+- **Initial render:** in `connectedCallback`, guarded-once, build the subtree.
+- **Update:** `attributeChangedCallback` (string config) and property setters (rich data) — both call your own update logic.
+- **Remount:** remove-then-reinsert fires `disconnected` → `connected` again, but **the instance survives** — its fields, its `Map`, persist (the JS object isn't destroyed). If you didn't tear down the subtree, it's still there. So remount is *stateful and cheap*, unlike React's destroy-on-unmount. The element and its state travel together as one thing.
+
+This maps onto azoth's triple almost exactly:
+
+| azoth | web component |
+|---|---|
+| `initialize` / constructor intake | `constructor` (state only, defer DOM) |
+| `render()` (no-args first paint) | guarded `connectedCallback` |
+| `update(newProps)` | `attributeChangedCallback` + property setters |
+| Channel (update, no render) | an element that only reacts to attribute changes |
+
+## The gotcha that decides the row design
+
+**Moving a connected custom element fires `disconnectedCallback` then `connectedCallback`.** A move is spec'd as remove-then-insert. So if your **rows** are custom elements, every `move()` churns lifecycle on them. If the rows are **plain `<li>`/`<tr>`** and only the *list* is the custom element, moves fire nothing — plain elements have no callbacks.
+
+→ **The list is the custom element; the rows are plain.** This also keeps `map`-produced rows as ordinary platform nodes, which is what you want for the CSS-as-view-logic story.
+
+And the modern platform answer to move-churn even for rich nodes: **`parent.moveBefore(node, ref)`** — a state-preserving move that does *not* fire disconnect/connect (preserves iframes, focus, animations, custom-element state). Chrome shipped it; I'd verify Firefox/Safari breadth before relying on it, but it's exactly the primitive a `KeyedList.move()` wants, and reaching for it is on-mission (use the platform's newest piece, don't reinvent reconciliation).
+
+## Two edges in your sketch
+
+**Shadow DOM fights your own CSS pillar.** You listed "and you get shadow DOM" as a pro — but shadow DOM *scopes styles away from the author*. The `[data-selected].status-adopted` view-logic we just enshrined lives in **author CSS**, and shadow DOM would wall the rows off from it (you'd be forced into `::part`/custom-props/slots). A custom element does **not** require a shadow root — render into **light DOM** (`this.append(...)`) and you keep the element + lifecycle + behavior-encapsulation *and* full author-CSS reach. My strong lean: **light DOM.** Shadow is for widgets that want style isolation; an azoth list wants the opposite.
+
+**Own from the semantic root down — it dissolves your `keyed-ul/keyed-table` worry.** Your sketch hit the real wall: `<keyed-list>` can't sit inside `<table>` (the table content model only admits `<tbody>/<tr>`), and a matrix of `KeyedUnorderedList/KeyedTable/...` breaks the clean single-axis Supabase encapsulation. The resolution is the one you reached — **creation in KeyedList** — made precise: the custom element **creates its own semantic root and children.** `<keyed-todos>` renders a real `<ul>` inside it; `MyTable extends KeyedList` renders a full `<table><tbody>` and manages `<tr>`. The wrapper sits wherever block content is legal; the *semantic* parent→child relationship (`ul→li`, `tbody→tr`) is created intact *inside*. That sidesteps the content-model problem **and** the customized-built-in (`is=`) Safari gap **and** keeps encapsulation single-axis: the **source** is the subclass's concern (`class SupabaseList extends KeyedList`), the **element type** is its `render`/template concern. One inheritance line, both axes, no matrix. "You see the container and the children" — exactly.
+
+So the shape I'd commit to: **KeyedList is a light-DOM custom element; authoring is `class MyList extends KeyedList`; it creates its semantic root and plain-element rows; `connectedCallback` is the guarded initial render; ops (`add/move/remove/update`) are imperative methods, not lifecycle; the instance carries its `Map` across remounts for free; reorders use `moveBefore` where available.**
+
+The one thing I'd still poke before settling: is `<keyed-todos>` as a *visible extra wrapper element* in the light-DOM tree acceptable to you, or does even one non-semantic node in the chain bother the structural sense? Because that's the price of the autonomous custom element (vs the unavailable `is=`), and it's the only real cost left on Route C.
+
+
+## Marty
+
+We've conflated controller and "list as authoring for custom elements" presentation. not KeyedList is a supabaselist, KeyedList has a supabase controller paired with a supabase source. 
+
+rerenderer never interfered with platform javascript semantics. Its "magic" in transpilation is a set of very simple rules about _a construct it owns JSX_ :em-dash: maya earns both her name and power - remains invisible yet controls DOM reality :em-dash: while not impeding on an existing js control flow or referencial integrety. The site base rendereding is exactly what a "DOM Literal" would mean.
+
+Apply this thinking to web components. and the magic here is that what we need to build is a much smaller surface area of what we need to support. we need to build up library of guidance patterns, which are additive and discoverable. but the rules azoth introduces strives it keep doors open, responsibility still rests with the author to adhere web standards (and what azoth has claimed is missing via it's ownership of JSX (and potenital primitives with exclusive access inside maya).
+
+Author could hook up supabase in constructor. supported. ( sketches, name-smithing welcome:) 
+use `new SupabaseController(source, list)`
+
+the unlock I'm looking for is:
+- author combines source and domain semantics as two sides of same coin. Leans on extends. Live pet Adoption implemented on Supabase is a <pet-adoption-dashboard>, or externalizes <pet-adoption-dashboard source={getRefFromImportedService()}>. 
+- author does semantic with slotting <pet-adoption-ul>, <pet-adoption-li>
+- author does do <supabase-list source={getRef()}> or <keyed-ul source={getRef()} controller={new SupabaseController()}> 
+- author has a way to decide what <pet-adoption-ul><li>felix</li><pet-adoption-ul> means
+
+because that's their API. 
+same with shadow dom. it's perfectatly legitimate
+
+what we _build_ is simpler, we don't have to boil the ocean, because are goal is to be the ocean. affordance for LLM high priority, that's where you can shine helping us out. we're hitting actual surface area of code.
+
+make easy cases easy, defaults sensible. allow web component sematics to be used _progressively_. the pitfalls _are those of the platform and the authors use of it_
+
+
+## Claude
+
+You caught a real conflation in my framing, and fixing it *is* the unlock.
+
+## The unlock: two orthogonal axes, composed — never crossed
+
+I wrote `class SupabaseList extends KeyedList` — which **crosses** presentation with source. That's what created the `keyed-ul / keyed-table × supabase / websocket` matrix anxiety. Your correction dissolves it: **KeyedList *has* a controller; it doesn't *become* one.**
+
+| Axis | What it is | How it attaches | Variants |
+|---|---|---|---|
+| **Presentation** | the element + keyed list-ops over `map`/`key` | `extends` (it's a custom element) | `KeyedUL`, `KeyedOL`, `KeyedTable` — the tag/semantics |
+| **Source** | bridges a data source → list ops | **composition** (`new …Controller(source, list)`) | `SupabaseController`, `ProtocolController`, … |
+
+Two axes, orthogonal. Pet adoption = **KeyedUL** (presentation) + **SupabaseController** (source) + **pet template** (domain). Three independent choices, no matrix — because source was never an inheritance concern. "Two sides of the same coin": the **controller** is the source side, the **element + template** is the domain side, and `extends` vs `source={…}` is just *where the author chooses to fuse them*.
+
+## This is the DOM-Literal principle applied to components
+
+maya owns one construct — JSX, the DOM literal — with simple rules, and never touches the JS around it. Apply that here and the build surface collapses:
+
+- **azoth builds:** the rerenderer (row update), the keyed list-ops primitive, JSX-as-DOM-literal. That's it.
+- **the platform provides:** the custom element, lifecycle, shadow/light DOM, CSS, slots.
+- **the author provides:** their element (their API), their controller, their templates.
+
+We don't wrap web components in a framework. JSX is just the DOM literal *inside* `connectedCallback`, and the custom element is plain author JS that maya never impedes. "We don't boil the ocean because our goal is to be the ocean" — exactly: own the literal, add the missing primitive, let the platform be the platform.
+
+## All your expressions fall out of the same three parts
+
+```js
+// SOURCE AXIS — the controller contract: source in, list ops out. Tiny.
+class SupabaseController {
+    constructor(source, list) {
+        this.sub = source
+            .on('INSERT', r => list.add(r.new))
+            .on('UPDATE', r => list.update(r.new.id, r.new))   // delta kept, no diff
+            .on('DELETE', r => list.remove(r.old.id));
+    }
+    dispose() { this.sub.unsubscribe(); }   // paired to disconnectedCallback
+}
+```
+
+```js
+// (A) baked — source + domain fused via extends → <pet-adoption-dashboard>
+class PetAdoptionDashboard extends KeyedUL {
+    map = pet => <li>{pet.name}</li>;
+    key = p => p.id;
+    connectedCallback() {
+        super.connectedCallback();                  // builds <ul>, paints initial rows
+        this.controller = new SupabaseController(petsSource, this);
+    }
+    disconnectedCallback() { this.controller?.dispose(); }
+}
+
+// (B) externalized — source handed in → <pet-adoption-dashboard source={getRef()}>
+class PetAdoptionDashboard extends KeyedUL {
+    set source(ref) { this.controller?.dispose(); this.controller = new SupabaseController(ref, this); }
+}
+
+// (C) generic primitive + injected controller
+<keyed-ul source={getRef()} controller={SupabaseController} map={petRow} key={p => p.id} />
+
+// (D) reusable source-typed list → <supabase-list source={getRef()} map={…}/>
+```
+
+Same parts, four assemblies. **The author's element is the API; azoth supplies the parts, never the assembly.** That's why `<pet-adoption-ul><li>felix</li></pet-adoption-ul>` can mean whatever they decide — slotting, light-DOM rows, shadow projection — *because it's their element*, and maya only owns the JSX literals inside.
+
+## Name-smithing
+
+- `SupabaseController(source, list)` — I'd keep **Controller**; you already reached for it ("simple controllers bringing source interfaces and list operations"), and it reads true: it controls the list from the source. `Sync`/`Binding`/`Feed` all narrow it wrongly (imply one direction or one verb). Controller is the honest noun.
+- Presentation: **`KeyedUL` / `KeyedOL` / `KeyedTable`** as thin tag-variants over a shared `KeyedList` core (the ops live in the core; the variant just fixes the root element). The matrix fear is gone now that source is off this axis.
+- `dispose()` for teardown — pairs cleanly to `disconnectedCallback`. (Mirrors Channel's `AbortController` story; same shape, author-clocked.)
+
+## Shadow DOM — you're right, retract my "law"
+
+I overstepped. Shadow DOM is legitimate; the author owns that tradeoff. The CSS-reach concern doesn't become a *restriction* — it becomes a **discoverable pattern**:
+
+> *Light DOM* keeps rows reachable by author CSS (the `[data-selected].status-adopted` view-logic). *Shadow DOM* isolates styles — reach rows via `::part` / custom properties / slots. Pick per your API.
+
+That's the correct register: guidance, additive, doors open. The pitfalls are the platform's, not azoth's to forbid.
+
+## LLM affordance — where the small surface pays off hardest
+
+This is the real leverage, and it's a direct consequence of "be the ocean": **a model already knows 90% of this.** Custom elements, lifecycle, DOM, CSS, shadow/slots — all deeply in training. So the docs' job is **not to re-teach the platform** — it's to *mark the deltas*:
+
+1. **Name the owned construct.** "JSX here is a DOM literal — it evaluates to DOM, maya owns it by these few rules, everything around it is plain JS you already know." A model reasons cleanly across that boundary. It's the single most teachable framing you have.
+2. **Mark azoth-specific bits inline.** In every example, the platform parts are unannotated (the model knows them); the *only* comments are on the azoth deltas (`map`/`key`, the rerenderer rebind, the controller contract). The comment density itself signals "this is the new surface; the rest is standard."
+3. **Pattern library = additive + discoverable.** Each pattern is one file: `name · when-to-use · minimal JSX+JS · snapshot`. Self-contained, learnable in isolation, indexed. This matches your existing discipline (maya tests are LLM examples, snapshot-backed). The four assemblies above are literally four patterns.
+4. **The controller contract as a stamped shape.** A model handed "source in, list ops out, `dispose()` to tear down" can write a `WebSocketController` or `RedisController` correctly on the first try — because the contract is three verbs and a teardown, and the source API is something it already knows.
+
+The smaller we keep the owned surface, the more the model's platform fluency carries the rest. Surface area *is* the affordance budget.
+
+---
+
+Concrete next step, since we're at real code: I'd **write the four assemblies as the first guidance patterns** — minimal, snapshot-backed, in the maya examples style — and **lift the shell** to the corrected shape (`KeyedList` core + `KeyedUL`/etc. tag-variants + the `Controller` contract documented, not coded). Want me to start with the pattern files (the discoverable library), the lifted shell (the buildable surface), or sketch the `KeyedList` core's connectedCallback/ops against the platform lifecycle first so the primitive is nailed before the patterns lean on it?
+
+
+## Marty
+
+immensively valuable material since I suggested we start riffing. 
+read the rest of prompt then be prepared to do both a dump of full conversation since that point (including thinking if that works and use subs to keep context window cleaner), and then a second file more intelligent look from where we've arrived focusing on the precision we now have since we started, doesn't need to argue the case the history is there, but does need to unpack and show clear line of site. the other artifacts need for below. commit and push. gold i say! 
+
+onward!
+
+`LLM affordance — where the small surface pays off hardest` those four points are :rockstar:
+llm story strong. rolls to eval based skills: did the llm use the pattern given the prompt?
+
+Go for authoring tests in Valhalla for DOM parts. I would do it first, because that's the correct answer from an eval pespective of "what yo u want the author" to be able to write" . Author-first exposes constraints early. But I'm not an LLM.
+
+Show writing the code you want work, use domain like syntax, not clever test accounting tricks. Let MatchInlineSnapshot() first generate do the work of driving for html because that's what JSX is contracted to do. 
+
+Controllers tests can control input of injected sources and lists, accounting tricks fine to simple stub/mock/dummy/whatever little simple js thing works. 
+
+This feels downhill so I want permission structure to encourage moving forward if low friction. There are a few threads so fine to halt one and continue others. 
+
+Make a .md plan for yourself. Feel free to leverage workflow and subagent flows, branch/commit strategies per your discretion
+
+Invitation to surface planning exposed discussion and questions before launching into the work! I could be jumping to soon. it feels like we defined our world but the platform/jsx stance. I'm both opening doors and upping the requirements, so no pressure to depart.
+
+
+## Claude
+
+This is the right place to pause, and your instinct is exact: **we defined the world, but not the platform/JSX stance** — and the author-first tests can't be written without it, because the first test you write *is* the stance, spelled out. So let me surface rather than launch. Plan artifact first, then the gap and the questions.
+
+_(wrote a private scratch execution plan: keyed-list-plan.md)_
+
+Plan's in scratchpad. Here's what I want your eyes on before I move.
+
+## The one real gap: author-first *is* stance-taking
+
+Your two instincts converge into a single thing. "Author-first exposes constraints early" + "we defined our world but the platform/jsx stance" → **the first author-first test forces the stance.** The moment I write the code I want the author to write, I have to commit to: what's the tag, how do props arrive, who owns the lifecycle. So the first test isn't a test — it's the stance decision, made concrete. That's *why* it's the correct eval-perspective answer, and also why I shouldn't write it casually. We should take the stance with eyes open, then let the snapshot generate the truth underneath it.
+
+So the gate before any author-first code is four questions — two are yours to decide, two I verify in the code:
+
+| | Question | Type | My lean |
+|---|---|---|---|
+| **Q1** | Tag: `<keyed-ul>` (platform-upgraded custom element) vs `<KeyedUL>` (azoth-instantiated component)? | **your call** | hyphenated/platform — it's the whole "be the ocean / DOM Literal" thesis |
+| **Q2** | Does azoth set dynamic props (`map`/`key`/`source`) *before* the element connects? | verify in code | needs to be true, or the element wants lazy-upgrade |
+| **Q3** | Can `rerenderer(rowFn)` instantiate per-row imperatively (Map<key, rerenderer(map)>)? | verify — **likely already de-risked** | your recent `rerenderer-per-row keyed` + `module-factory … returned closure is the rerenderable` commits look like exactly this |
+| **Q4** | Once defined, does it leave azoth compose entirely (pure platform lifecycle)? | your call, leans obvious | yes — cleanest DOM-Literal outcome |
+
+Q1 is the keystone; everything downstream spells from it. My read of everything you've said points hard at **hyphenated, platform-upgraded, light-DOM by default** — but it's your stance to plant, and it's the thing I won't assume.
+
+## Autonomy structure (so low-friction work just moves)
+
+- **Green** — proceed + commit per increment, no check-in: docs, more patterns once the first is validated, snapshot regen, green-test refactors.
+- **Yellow** — proceed but report at the commit boundary: a new pattern introducing a new authoring shape (so you can object after, not before).
+- **Red** — halt *that* thread, surface, keep the others moving: a constraint that contradicts the design (Q3 failing), or a stance fork (Q1/Q4).
+
+Threads are parallel; halting one never blocks the rest. Branch `keyed-list` off main, commit per increment, push at checkpoints.
+
+## Sequence
+
+1. **Docs** — dump (via an Explore subagent reading the session `.jsonl`, including thinking, so the raw text never hits my context) + synthesis (ends with these open questions as honest line-of-sight). Commit + push. **Safe, independent — I can run this now.**
+2. **Resolve Q1–Q4** — the gate.
+3. **First author-first test** = the stance, concrete. Validate.
+4. **Fan out** — the four assemblies as patterns + controller tests (mocks fine).
+
+And yes — your eval reframe lands: a pattern's definition-of-done isn't "is it correct," it's **"given a realistic prompt, does the model reach for it?"** That makes the pattern library a set of eval targets, not just docs. I've folded it into the synthesis's affordance section.
+
+---
+
+Where I'd like your steer before launching:
+
+1. **Q1 + Q4** — plant the stance (or tell me to verify-then-recommend and you'll ratify).
+2. **Docs now, in parallel?** I read step 1 as Green — want me to kick off the dump + synthesis (commit/push the docs checkpoint) while we settle the stance? Or hold everything until Q1 is planted?
+3. **Are you jumping too soon?** My honest read: no — *if* we treat the first author-first test as the stance ceremony rather than as routine test-writing. The world is defined enough that author-first will productively expose the rest. The risk isn't earliness; it's writing the first test on autopilot and letting an accidental stance harden. Naming it removes that risk.
+
+Onward — just point me at the first thread.
+
+
+## Marty
+
+clarifications: 
+- prefer rythm of consistently flusing to docs. 
+- code-smiting not just name-smithing :)
+
+Q1 <keyed-ul> for reasons:
+
+you said it yourself, it's the similar interface on init/render/update and <KeyedUL> puts those into conflict. there two sides of the same pattern: js initiated flow, custom-element platform initiated flow. <keyed-ul> is purely platform (Q4). it comes from the template which instantiates on web load to prep the content fragment, right? what is impact of that on load cycle? we'll have to nail this down.
+
+it's a context frame change with a reset. it's like a new render cycle out of the original render flow. remember why we got into this, a complex set a functionality that falls outside of the forward-only case. 
+ 
+Azoth components can return custom-elements. The author doesn't need know implementation details to intgrate at the component compsition level: 
+
+```jsx
+<main>
+    {/* structural elements */}
+    <PetFilter/>
+    {/* structural elements */}
+    <PetAdoptionDashboard/>
+    {/* structural elements */}
+    {/* ... */}
+</main>
+```
+
+```
+class PetAdoptionDashboard(...) extends KeyedUl /*or KeyedList with internal, or ...*/
+{
+    /* authoring story new chapter about doing the dashboard...
+}
+```
+
+I didn't include source. I've seen both patterns used effectively of module level direct source, and main-level injected. as props. in-module works well for realtime systems because you don't need to notify the realtime does it. you can also expose and use events. or in this case a pushable might be all you need to turn the wheel.
+
+why not <keyed-ul>? 
+
+Depends on pain of custom element registration work and timing. 
+need to see template-inclusion consequence - help or hinder.  LLM covers "that's too much ceremony to type" and "what's the right way to do this", but this is structural delivery via platform.
+
+
+Q2,Q3,and custom element registration and load - these are three spikes (research and/or test cases) to resolve that I recall. 
+
+
+Let me know if i dropped something
+
+
+## Claude
+
+Stance received and it's the right one — and your reasoning sharpens a precision we hadn't named yet. Let me reflect it, code-smith it, flush it to the doc (starting the continuous-flush rhythm), then confirm the spikes.
+
+_(wrote the living design doc: docs/design/keyed-list.md)_
+
+Flushed to `docs/design/keyed-list.md` — that's the continuous-doc rhythm started; I'll keep landing decisions there as we go.
+
+## The precision your Q1 reasoning unlocked
+
+You said it as "context frame change with a reset… a new render cycle out of the original render flow" — and that's the thing we hadn't named. **The custom element *is* the frame boundary between the two render modes.** Forward-only render builds the page, hits `<pet-adoption-dashboard>`, and hands off to a second self-managing cycle owned by the platform. That's *why* it had to be a custom element and not an azoth component: the dynamic case lives outside forward-only, so it gets its own frame — it doesn't thread back into the page's render. `<KeyedUL>` would have forced it back through the JS-initiated init/render/update path — the conflict. `<keyed-ul>` keeps it pure platform (Q4).
+
+And the seam reads it off the spelling, no invented syntax:
+
+```jsx
+<main>
+  <PetFilter/>                {/* Capitalized → azoth component, JS-initiated, forward-only */}
+  <pet-adoption-dashboard/>   {/* hyphenated → custom element, platform-initiated, own cycle */}
+</main>
+```
+
+So your `<PetAdoptionDashboard/>` sketch resolves to **hyphenated** — and the casing is a *feature*: JSX's existing lower/Capitalized convention plus the platform's hyphenation convention give us the two-flows distinction for free. That's the answer to the composition-tag question, and it's a free win.
+
+## Code-smith: source is the author's wheel, wired anywhere
+
+Your "I didn't include source on purpose" is exactly right — it's the orthogonal axis, so it doesn't belong in the element's identity. Sketched all four in the doc; the two poles:
+
+```js
+// module-level direct — realtime self-drives; "you don't notify it, it notifies you"
+const pets = supabase.channel('pets');
+connectedCallback() {
+    super.connectedCallback();
+    pets.on('postgres_changes',{event:'INSERT'}, ({new:p}) => this.add(p))
+        .on('postgres_changes',{event:'UPDATE'}, ({new:p}) => this.update(p.id, p)).subscribe();
+}
+
+// pushable — "all you need to turn the wheel"
+const [pets$, push] = pushable();
+connectedCallback() { super.connectedCallback(); (async () => { for await (const p of pets$) this.add(p); })(); }
+```
+
+## The three spikes — and I already know part of spike 3
+
+1. **Prop timing (Q2)** — does azoth set `row`/`key`/`source` *before* connect? Determines whether we need lazy-property-upgrade.
+2. **Rerenderer per-row (Q3)** — `rerenderer(rowFn)` instantiated imperatively, one per row, keyed. **Likely already de-risked** by your `rerenderer-per-row keyed` + `module-factory … returned closure is the rerenderable` commits — the spike confirms, doesn't discover.
+3. **Registration + load + template-inclusion** — here's the platform baseline so the spike *measures* rather than gropes: a `<template>`'s `.content` is **inert** (separate document), so a `<keyed-ul>` inside it **doesn't upgrade while in the template** — it upgrades on *insertion* into the live doc (or at `define()` if already inserted). So `connectedCallback` fires as the cloned fragment lands in the tree. The open part — and your real question — is the **load-cycle cost**: a heavy `connectedCallback` (subscribe/fetch) fires *during* initial render. The spike confirms azoth's clone/insert path matches the spec and measures that cost.
+
+## Did you drop something? A few small things, parked in the doc:
+
+- **extends vs compose** — `extends KeyedUL` (element IS the list) vs `extends HTMLElement` + composes a `KeyedList` core (element HAS a list). This is your "/*or KeyedList with internal*/" — it's the "one primitive or two" fork. The registration spike informs it; not blocking.
+- **`map` → `row`** — lean to rename (reads as the row template; dodges Array.map ambiguity).
+- **Autonomy structure** — I took your silence as accepted; say so if not.
+- **The dump** — still want the raw transcript captured (via subagent, context-clean) alongside this living doc? The doc is the synthesis; the dump is the history.
+
+## Next
+
+Per the autonomy structure, the spikes are Green-ish (Explore/research), and they're the gate. My plan: run the **three spikes as Explore subagents** (keeps my context clean), each returning a verdict + the minimal evidence, then flush results to the doc. Spike 3 is the one that could surface a Red (load-cycle cost) — I'll halt that thread and surface if so, keep the others moving.
+
+Want me to kick off the three spikes now, and run the transcript-dump subagent in parallel? Or is there more frame to set before I depart?
+
+
+## Marty
+
+one  concern to call out: we need to check if our custom element thoth dom part generation is using dynamic jsx as  js prop. i think static is set attribtute.
+
+
+Is the custom-element frame also a rerenderer reset? I don't know we can strictly enforce (maybe) but can support. We already documented the potential need for reseting rerenderer flow control, let's call it a `renderer` function for different Class that put's itself on the stack in packages/maya/renderer/renderer.js:
+
+```js
+
+export function activeRerenderer() {
+    return stack.length ? stack[stack.length - 1] : null;
+}
+```
+
+function rename more like activeRenderer which can be a regular renderer (new dom) or a rerenderer (reuses dom). is there need for third word here?
+
+and in renderer.js `const rr = activeRenderer()` can then be tested or otherwise casue the right skip:
+
+```js
+if(rr && create) {
+    ({ node: root, bind } = rr.getBound(siteKey, buildFresh));
+}
+else {
+    ([root, bind] = getBound());
+}
+```
+
+in general i think it helps to support authoring  works in constructor based because thunk syntax (either just using functions or forced into by renderer((props) => {}) is defining functions to run jsx, but not actually creating instantiating but logically feels like constructor right place to define. connected/disconnect cylces through. constructor safe place for one time stuff.
+
+If there are a finite set of meaningful html list elements the direction I'm facing towards extending KeyedTAG. They are simple derivations over KeyedList, which itself is exposed for doing "author initiated, potential not semantic html stuff or gaps or exploring the platform"
+
+row is table. item is list. both nouns it's a function. template as verb? (loaded!). map gets more love in async iter helpers (included right?). anything more verby?
+
+Autonomy structure G,Y,R is great. 
+
+go ahead and keep the dump up to date if that works, keeping your context as clean as possible. I'm finding the collaboration is smooth, I wonder if it might be beneficial for people to see what the pace looked like between us that actually makes forward strives, innovating, medium n(still a process of learning!) looks like. or people who struggle to imagine llm as more than search engine or tool.
+
+
+## Claude
+
+This turn is real implementation territory, so let me ground it in the actual code rather than reason in the abstract. Reading `renderer.js` for the stack/`activeRerenderer` machinery you quoted, and sending two agents out in parallel — one to settle the thoth concern (which is the sharp one), one to keep the dump current without loading it into my context.
+
+_(read packages/maya/renderer/renderer.js)_
+

--- a/docs/design/keyed-list.md
+++ b/docs/design/keyed-list.md
@@ -1,0 +1,380 @@
+# KeyedList — design (living doc)
+
+> Status: stance planted (Q1, Q4), spikes pending. Flushed continuously as we
+> decide. History/argument lives in the transcript; this doc states *where we
+> arrived* with clear line of sight. Related: [rerenderer](./rerenderer.md),
+> [VirtualList](./VirtualList.md).
+
+## What this is
+
+The narrow **dynamic-list specialty**: add / remove / move / update over keyed
+rows, with each change keeping its delta (no reconcile-by-diff). NOT a
+list-rendering abstraction — 95% of "lists" are forward-only `{items.map(row)}`
+at initial render and need none of this.
+
+## The frame boundary (the core precision)
+
+A page's forward-only render flow builds structure and, at a `<keyed-ul>`,
+**hands off to a second, self-managing render cycle.** The custom element is a
+*context-frame change with a reset* — a new render cycle out of the original
+flow. This is exactly why we needed it: the dynamic case falls outside
+forward-only, so it gets its own frame, owned by the platform, not threaded
+back into the page's render.
+
+Two sides of one pattern, distinguished at the composition seam **by casing**
+(JSX convention + platform convention, no invented syntax):
+
+```jsx
+<main>
+  <PetFilter/>                  {/* Capitalized → azoth component, JS-initiated, forward-only */}
+  <pet-adoption-dashboard/>     {/* hyphenated → custom element, platform-initiated, own cycle */}
+</main>
+```
+
+The author reads the render flow from the spelling. That's the payoff of Q1.
+
+## Renderer reset (the frame boundary, expressed in code)
+
+The conceptual frame boundary has a 1:1 expression in `renderer.js`. Today the
+per-site closure dispatches on `activeRerenderer()`: a rerenderer active →
+`rr.getBound(siteKey, buildFresh)` (reuse DOM); else legacy `getBound()`
+(fresh). Generalize the stack to hold **renderers of two kinds**, both
+implementing `getBound(siteKey, buildFresh)`:
+
+- **Rerenderer** — caches by `siteKey`, reuses DOM. (exists)
+- **Renderer (fresh)** — ignores `siteKey`, always `buildFresh()`. The reset.
+
+Rename `activeRerenderer` → **`activeRenderer`**; the closure becomes uniform
+(polymorphism handles the dispatch — a fresh Renderer's `getBound` just builds):
+
+```js
+const r = activeRenderer();
+if (r && create) ({ node: root, bind } = r.getBound(siteKey, buildFresh));
+else ([root, bind] = getBound());   // legacy path, removed when blocks migrate
+```
+
+A `<keyed-ul>` **pushes a fresh Renderer** around its internal render (in
+`connectedCallback`). Consequences:
+- the page's outer rerenderer is **shadowed** — it cannot reach into the
+  element's internals. This is Q4 (pure platform) enforced at the renderer level.
+- rows build fresh by default; per-row, KeyedList pushes a per-row **Rerenderer**
+  for `update()` — nests cleanly on the same stack.
+- **de-risks the load-cycle timing:** because the element pushes its own frame,
+  it no longer matters *when* `connectedCallback` fires relative to the page
+  render — the outer stack state is shadowed either way.
+
+**Third word? No.** Two concepts span it — Renderer (new DOM) / Rerenderer
+(reuse). The "reset" is just a Renderer pushed to shadow; not a third kind. The
+candidate third concept would be a **rerender-nothing barrier** — something that
+*blocks reuse without itself reusing*. But that is exactly what a fresh Renderer
+is: it renders new DOM and, by sitting on top of the stack, blocks the outer
+rerenderer's reuse. (Precisely: not *render*-nothing — it does render fresh DOM;
+it *rerenders* nothing.) A pure produces-no-DOM barrier has no use we can see.
+Subtract to unlock — two words.
+
+## Stance (decided)
+
+- **Q1 — tag:** hyphenated **`<keyed-ul>`**, platform-upgraded custom element.
+  Not `<KeyedUL>` (azoth component): a custom element is `HTMLElement`-derived
+  with the platform's connected/disconnected lifecycle; routing it through
+  azoth's JS-initiated init/render/update protocol puts the two flows in
+  conflict. Hyphenated keeps it purely platform.
+- **Q4 — compose:** once defined, the element **leaves azoth compose entirely.**
+  Lifecycle is 100% platform (connectedCallback = initial render; ops = imperative).
+- **DOM default:** light DOM, so author CSS reaches rows (the
+  `[data-selected].status-adopted` view-logic). Shadow DOM is legitimate —
+  guidance, not law: use it for isolation, reach rows via `::part`/custom props.
+  - *Reminder (matters for CSS):* a custom element is just **markup** — it sits
+    in the template HTML, gets cloned, and the platform upgrades it on insertion
+    (same as any element; see Bootstrap). Because it's real markup in light DOM,
+    author CSS styles the element and its rows normally — no special render
+    layer between the stylesheet and the rows. That's the floor under
+    CSS-as-view-logic.
+- **Two orthogonal axes** (never crossed):
+  - *Presentation* — an abstract base **`KeyedList`** (shared ops; `extends
+    HTMLElement`; **NO tag, NO define** — the extend target) with concrete leaves
+    **`KeyedUList`/`KeyedOList`/`KeyedTable`** (the finite keyed set), each its
+    OWN module with its OWN `define`. Author `extends` a leaf (semantic) or
+    `KeyedList` itself (raw/custom) and `define`s their own tag. The define-free
+    base keeps each leaf's registration isolated. See *Bootstrap & module layout*.
+  - *Source* — bridges a data source → ops (`SupabaseController`, …), attached by **composition**.
+
+## Authoring story (code-smith, pre-spike)
+
+Domain element extends a presentation base; the row template + key are its
+declaration; the source is wired wherever the author likes.
+
+```js
+class PetAdoptionDashboard extends KeyedUL {   // KeyedUL derives KeyedList; fixes <ul>/<li>
+    constructor() {
+        super();
+        this.key  = pet => pet.id;                                                  // function-valued props (thunks):
+        this.view = pet => <li class={`pet status-${pet.status}`}>{pet.name}</li>;  // the row's rerenderable
+    }                                          // constructor: once. connected/disconnected: cycle.
+
+    connectedCallback() {
+        super.connectedCallback();   // base pushes a fresh Renderer frame, guards the once-render
+        // source wired in JS (pattern 1/3) — no rich JSX props needed
+    }
+}
+customElements.define('pet-adoption-dashboard', PetAdoptionDashboard);
+```
+
+Constructor for definitions, `connectedCallback` for the cycle: the thunk forms
+(`renderer(props => …)`) *define* a function that runs JSX without instantiating
+— for a custom element the constructor is the honest once-place for that
+(`key`, config), since connected/disconnected cycle through repeatedly. The
+constructor only *stores closures* (no DOM, no attribute reads → within WC
+constructor rules); the JSX runs later, under the element's own fresh frame.
+
+### Source patterns (author's choice — all legitimate)
+
+```js
+// (1) module-level direct — realtime self-drives; you don't notify it, it notifies you
+const pets = supabase.channel('pets');
+connectedCallback() {
+    super.connectedCallback();
+    pets.on('postgres_changes', {event:'INSERT'}, ({new:p}) => this.add(p))
+        .on('postgres_changes', {event:'UPDATE'}, ({new:p}) => this.update(p.id, p))
+        .on('postgres_changes', {event:'DELETE'}, ({old:p}) => this.remove(p.id))
+        .subscribe();
+}
+
+// (2) injected at composition — <pet-adoption-dashboard prop:source={getRef()}/>
+set source(ref) { this.#ctl?.dispose(); this.#ctl = new SupabaseController(ref, this); }
+
+// (3) pushable — minimal driver, "all you need to turn the wheel"
+const [pets$, push] = pushable();
+connectedCallback() { super.connectedCallback(); (async () => { for await (const p of pets$) this.add(p); })(); }
+
+// (4) events — DOM-native, fan-out for free
+this.addEventListener('pet:adopted', e => this.update(e.detail.id, {status:'adopted'}));
+```
+
+### Ops (verbs)
+
+`add(...items)` (variadic, append-like, for inline/few) **and** `addAll(items)`
+(an array, the bulk path) · `update(key, data)` · `move(key, index)` ·
+`remove(key)` · `clear()` · `has(key)` · `get(key)` · `size` · `keyAt(target)`.
+
+Why both `add` and `addAll`, not variadic-only (`add(...all)` mirroring
+`element.append`): a list is the **big-N** case — `add(...10_000)` risks
+argument-count limits, which `addAll(array)` sidesteps. And variadic-only has an
+**LLM footgun**: `add(rows)` (forgetting the spread) silently adds *one* row
+whose data is the array, rather than erroring — and we can't guard it without
+breaking the legitimate "a row whose data is an array" case. So `addAll` stays
+as the safe, unambiguous bulk door; `add(...items)` gives the append feel for
+inline use. (This is the resolution of the earlier `add(oneOrMany)` ambiguity.)
+
+### Controller contract (source axis)
+
+```js
+class SupabaseController {
+    constructor(source, list) { /* subscribe; map events → list.add/update/remove */ }
+    dispose() { /* unsubscribe — pair to disconnectedCallback */ }
+}
+```
+
+This is a **contract** (a shape the author/library implements), not a built-in —
+**azoth ships no controller.** Per "no general problems," specific controllers
+(Supabase, WebSocket, …) are examples/recipes; one is promoted to library code
+only if a genuinely reusable shape emerges. The integration mechanism is
+author-defined by design.
+
+## Bootstrap & module layout (the hand-off seam)
+
+The tricky part of pure-platform: **a hyphenated tag in the template is just a
+string.** `<keyed-ul>` compiles into the template HTML with *no JS reference* to
+the class — unlike a Capitalized `<KeyedUL/>` component, which compiles to the
+imported identifier (a binding the bundler tracks). So the bundler sees **no
+link** from the tag to the class module. The element upgrades only if
+`customElements.define('keyed-ul', …)` has run.
+
+**The define side-effect IS the hand-off.** Something must run `define`; using
+the tag doesn't pull it in. Consequences:
+
+- **Author must import the defining module.** Either the `extends` does it
+  (`class X extends KeyedUL` references `KeyedUL` → its module is kept → its
+  `define` runs), or — for raw `<keyed-ul>` use with no subclass — a side-effect
+  import is required. Forgetting it = a silent inert element (no upgrade). This
+  is a real footgun and a first-class LLM-affordance/docs point.
+- **Treeshaking:** package `sideEffects` must protect the per-element modules so
+  `sideEffects:false` can't drop a `define` whose class binding looks unused
+  (the raw-tag case). The `extends` case is naturally safe (binding is used).
+
+**Module layout (driven by treeshaking):**
+
+```
+KeyedList       abstract · shared ops · NO define · the extend target  (shared module)
+ ├─ KeyedUList  → define('keyed-ul')     own module
+ ├─ KeyedOList  → define('keyed-ol')     own module
+ └─ KeyedTable  → define('keyed-table')  own module
+```
+
+The base is **abstract on purpose:** if `KeyedUList` extended a *concrete*,
+self-defining list, importing `keyed-ul` would drag that element's `define` in
+too — a leak. A **define-free** base means importing one leaf registers only its
+own tag. (Extending the base directly is even leaner — no ride-along at all.)
+
+**Only three keyed elements** — `ul`/`ol`/`table`. The rest (`dl`, `menu`,
+`select`, `datalist`) are typically initial-render-only (forward-only `map`), so
+they get no keyed leaf; an author needing a dynamic one `extends KeyedList`
+directly. (`dl`'s two-element items — `dt`+`dd` — also break the single-root-row
+model, an extra reason it's not a default leaf.)
+
+**Registration:** leaves self-`define` their canonical tag, **idempotently**
+(`if (!customElements.get(tag)) define(tag, cls)`) so a double-load can't throw.
+The author always `define`s their *own* tag for their subclass — `extends
+KeyedUList` gives `keyed-ul` along for the ride (one negligible registry entry,
+the cost of single-import) plus the author's `define('pet-dashboard', …)`. Chosen
+over a `KeyedUList.define()` method, which would split into two import styles
+(extend vs register-for-raw-use) to save one trivial registry entry.
+
+**Class casing — mirror the DOM stems:** `KeyedUList`/`KeyedOList`/`KeyedTable`
+(echo `HTMLUListElement`/`HTMLOListElement`/`HTMLTableElement`, minus the
+redundant `…Element`). On-mission (azoth mirrors the platform) and consistent
+(all `Keyed`+noun). Tags stay short + lowercase — `keyed-ul`/`keyed-ol`/
+`keyed-table` — class name and tag are independent. `KeyedUL`/`KeyedOL` is the
+terser alternative; the full `…Element` mirror is overkill.
+
+## Status
+
+- **GREEN (first increment).** `KeyedList` base + `KeyedUList` leaf implemented
+  (`packages/maya/blocks/`); both author-first tests pass; valhalla 59/59, maya
+  143/143, no regressions. Snapshots:
+  `<pet-list><ul><li>Felix…</li><li>Mittens…</li></ul></pet-list>` and, after
+  `update(1, Felicia)`, `<li>Felicia…</li>` with Mittens untouched.
+- **Q3 empirically confirmed:** `expect(after).toBe(before)` passed — `update`
+  rebinds the row IN PLACE (same node) via its per-row rerenderer. Not just
+  reasoned now; observed.
+- **Fresh-Renderer frame: deferred, possibly moot.** Green with NO `renderer.js`
+  change: the container is built with `document.createElement` (no rerenderer
+  involvement) and each row's rerenderer self-pushes/pops, so the element's
+  internals never consult an outer rerenderer. The frame reset / `activeRenderer`
+  rename is robustness for the *nested-inside-a-rerenderer* case — a nested-usage
+  test would settle whether it's ever needed. Subtract candidate. **TODO: write
+  that nested-usage test.**
+- **Separate concern — the outer rerenderer updating the element's PROPS** (not
+  reaching into its internals). If the author binds a dynamic prop on the
+  element, the outer rerenderer re-assigns it on re-render:
+  `<keyed-ul source={dynamicRef} id={selector}>`. The element must *handle* the
+  update — **author responsibility, by design** (controlled component). Pattern,
+  mirroring Channel's same-source no-op:
+  ```js
+  set source(next) {
+      if(next === this.#source) return;   // idempotent: identical ref, no-op
+      this.#ctl?.dispose();                // teardown
+      this.#source = next;
+      this.#ctl = new SupabaseController(next, this);  // setup
+  }
+  ```
+  *Guidance:* if you expose a prop on a keyed element that an outer rerenderer
+  will rebind, your setter must handle the update (idempotent + teardown/setup).
+  Not gating; exercise when we add dynamic-prop tests.
+- **vitest `-u` coalescing bug RECURRED — without `/* HTML */`.** On `-u`, both
+  snapshot values were written onto test 1's call (test 2's left empty). Trigger
+  appears to be the `//` comments adjacent to the snapshot lines (the greedy
+  comment-skip), NOT the `/* HTML */` marker. Contradicts CLAUDE.md's
+  "regeneration-safe regardless of vitest version" — present in 4.1.8. Worked
+  around by placing the (vitest-generated) values by hand. Needs a call: strip
+  adjacent comments for `-u`-safety, or check the upstream fix's status in 4.x.
+- **Q3 (per-row rerenderer): CONFIRMED.** `rerenderer()` mints a `new Rerenderer()`
+  per call with a per-instance `#sites` cache; `Map<key, rerenderer(view)>` gives
+  each row an independent instance, so the same `view` (same `siteKey`) can't
+  collide across rows, and `update(key,data)` rebinds in place. Existing tests
+  cover ordinal (single-instance loop) + multi-site/single-instance; the per-row
+  multi-instance path is structurally guaranteed and now covered by the
+  author-first test.
+- **Author-first test:** `packages/valhalla/keyed-list.test.tsx` — the stance,
+  RED until `KeyedUList` implemented. Drives the build.
+- **New constraint surfaced (author-first working):** the JSX form `<pet-list/>`
+  needs a custom-element **IntrinsicElements** declaration in the JSX types, or
+  it's a TS error. The first test sidesteps it via `document.createElement`;
+  wiring custom-element JSX typing is the next author-first increment.
+- **Base typing lands WITH the implementation** (`.d.ts` or JSDoc on the
+  `KeyedList`/`KeyedUList` source, per maya's convention) so valhalla
+  typechecks rather than red-on-missing-type.
+- **Module home rename is a POST-impl refine, not an early gate.** `blocks` is
+  legacy (KeyedBlock vocabulary); the new name settles during the legacy-cleanup
+  increment that *follows* the implementation — which also removes
+  `Controller`/`Updater` + the injectable/`getBound` path in `renderer.js` (the
+  KeyedList-on-Rerenderer migration is what frees them). Renaming an export +
+  one import under green tests is a one-line refactor; deferring costs nothing,
+  nailing it early bikesheds the layout before we know what lives where.
+
+## Spikes (the gate before author-first tests)
+
+1. **Prop kind + timing (Q2) — INVESTIGATED, partial Red.** thoth codegen:
+   static value → attribute baked into the template; dynamic value →
+   `resolveDynamic(name, tag)` picks property-vs-attribute **by name, with no
+   custom-element special-casing.** A *known* DOM property name → property
+   assignment (good). An *unknown* name (`source`/`row`/`key` on `<keyed-ul>`)
+   → `setAttribute(name, value)` → **a rich value (ref/fn) stringifies to
+   `"[object Object]"`. Broken.** No way to force property for an unknown name
+   today — this is the TODO's "attribute vs property" gating issue surfacing here.
+   - **Consequence — the constructor/class authoring sidesteps it entirely:**
+     `key`, `present()`, and JS-wired sources never travel as JSX props, so the
+     broken path is never taken. ✓ This finding *validates* the class-based stance.
+   - **Only JSX-injected source (pattern 2) is blocked** → needs a force-property
+     syntax (`prop:source={ref}`), which is pre-existing needed surface (attr/prop
+     table work). Halt that sub-thread; patterns 1/3/4 are clear. (String-
+     identifiable sources, e.g. `source="pets"`, work today as a string attribute.)
+   - Timing: `renderer.js` `buildFresh()` clones → binds → *then* the caller
+     inserts, so props are set on a **not-yet-upgraded** element (a detached
+     clone isn't upgraded until connected). Assigning `el.view = fn` pre-upgrade
+     sets an own data property that **shadows the prototype setter** installed at
+     upgrade → setter never fires. Classic WC trap.
+   - **Resolution (two small, general fixes — not KeyedList hacks):**
+     (a) make dom-info `resolveDynamic(name, tag)` **tag-aware** — a hyphenated/
+     custom tag + unknown name → `kind:'property'` (NOT uniform dynamic→property,
+     which would break intrinsic force-attribute cases: aria/data/SVG/enumerated).
+     `makeBind` then emits `t.view = v`. One spot; no new channel; no runtime change.
+     (b) **lazy-property-upgrade** in the `KeyedList` base `connectedCallback`
+     (cache own value, delete, re-set through the accessor). Standard pattern.
+     Together these make `<keyed-ul view={petRow} key={byId}>` work — JSX-settable
+     rich props for ANY custom element, which is azoth correctly supporting the
+     platform. Needed only for JSX-injected props; constructor wiring needs neither.
+
+### Creation channel — no `createCustomElement` needed
+
+`METHOD = ['', '__c', '__cC', '', 'Object.assign']`: `__cC` (composeComponent)
+is for **capitalized** JSX components; `__c` is child compose. A hyphenated
+`<keyed-ul>` is neither — it's **plain element markup baked into the template
+HTML**, instantiated by clone + upgraded by the platform. The *only* runtime
+touch is `BIND.PROP` for its dynamic props (the fix above). So Q1 (hyphenated)
+is exactly what lets a custom element ride the element path: no new compose
+channel, no component protocol — pure platform.
+2. **Rerenderer per-row (Q3)** — can `rerenderer(rowFn)` instantiate
+   imperatively, one per row, same `row` fn, keyed in a Map? *Likely already
+   de-risked* by recent `rerenderer-per-row keyed` + `module-factory … returned
+   closure is the rerenderable` work — confirm the contract holds for the
+   imperative use.
+3. **Registration + load cycle + template inclusion** — `<keyed-ul>` rides in
+   azoth's compiled `<template>`. Platform baseline: template `.content` is
+   inert (separate document) — custom elements inside **don't upgrade while in
+   the template**; they upgrade on *insertion* into the live document (or at
+   `define()` time if already inserted). So upgrade + connectedCallback fire as
+   the cloned fragment lands in the tree. Spike confirms azoth's clone/insert
+   path matches, and measures the load-cycle cost (a heavy connectedCallback —
+   subscribe/fetch — fires during initial render).
+
+## Open forks
+
+_Resolved this round:_ **auto-define (idempotent)** over explicit `.define()`;
+generic `<keyed-list>` leaf **dropped** (abstract `KeyedList` IS the extend
+target); keyed set = **`ul`/`ol`/`table`**; class names **mirror DOM stems**
+(`KeyedUList`/`KeyedOList`/`KeyedTable`).
+
+_Resolved earlier:_ layering → abstract base + per-leaf define modules; row-fn
+name → **`view`** (function-valued prop); composition casing → **hyphenated**
+(marks the render flow); pure-platform creation (no `createCustomElement`).
+
+## LLM affordance (why the small surface wins) + eval framing
+
+A model already knows custom elements, DOM, CSS, lifecycle. Docs mark the
+*deltas*, not the platform: (1) name the owned construct — JSX is a DOM Literal;
+(2) annotate only azoth-specific bits in examples; (3) pattern library =
+additive, discoverable, one file each (`name · when · minimal JSX+JS ·
+snapshot`); (4) the controller contract is a stamped shape. **Eval reframe:** a
+pattern's definition-of-done is "given a realistic prompt, does the model reach
+for it?" — patterns are eval targets, not just docs.

--- a/docs/design/keyed-list.md
+++ b/docs/design/keyed-list.md
@@ -247,13 +247,16 @@ terser alternative; the full `…Element` mirror is overkill.
 - **Q3 empirically confirmed:** `expect(after).toBe(before)` passed — `update`
   rebinds the row IN PLACE (same node) via its per-row rerenderer. Not just
   reasoned now; observed.
-- **Fresh-Renderer frame: deferred, possibly moot.** Green with NO `renderer.js`
-  change: the container is built with `document.createElement` (no rerenderer
-  involvement) and each row's rerenderer self-pushes/pops, so the element's
-  internals never consult an outer rerenderer. The frame reset / `activeRenderer`
-  rename is robustness for the *nested-inside-a-rerenderer* case — a nested-usage
-  test would settle whether it's ever needed. Subtract candidate. **TODO: write
-  that nested-usage test.**
+- **Fresh-Renderer frame: CONFIRMED MOOT — subtracted.** The nested-usage test
+  (KeyedUList inside a rerenderer pass) is green: an outer re-render reuses the
+  `<pet-list>` node by site, rebinds its own bindings, and the element's
+  imperatively-managed rows survive untouched. The outer rerenderer never
+  reaches into the element's internals — the container is built with
+  `document.createElement` (no rerenderer) and each row's rerenderer
+  self-pushes/pops. So the custom-element boundary *is* the frame boundary,
+  structurally; the `activeRenderer` rename / explicit fresh-frame push is NOT
+  needed. (The design anticipated needing it — turns out the structure provides
+  it for free.)
 - **Separate concern — the outer rerenderer updating the element's PROPS** (not
   reaching into its internals). If the author binds a dynamic prop on the
   element, the outer rerenderer re-assigns it on re-render:

--- a/docs/design/keyed-list.md
+++ b/docs/design/keyed-list.md
@@ -37,9 +37,21 @@ The author reads the render flow from the spelling. That's the payoff of Q1.
 (JS-flow, runs-once-returns-rerenderable) covers two jobs — **tactical DOM-
 manipulation encapsulation** and **compositional work** — and *neither needs a
 new frame*; both live inside the page's forward-only render. Reach for a custom
-element only when the work is **dynamic and self-managing** (add/remove/move/
-update over time) — the case that falls outside forward-only and earns its own
-cycle. KeyedList is that case; most encapsulation/composition is not.
+element only when the work is **dynamic and self-managing in a way not addressed
+by replaying the same data structure over the same templates** via the
+rerenderer (which already does array-replay / ordinal reuse — the loops case).
+KeyedList qualifies: keyed deltas (add/remove/move of individual rows over time,
+sources that emit deltas not snapshots) don't reduce to "render the new array."
+Most encapsulation/composition does, and stays a UIComponent. (More art than
+science — this is the recognition test.)
+
+**The frame is a REPLICABLE author pattern, not privileged.** KeyedList imports
+only the public `rerenderer` + platform (`HTMLElement`, `document`, `Map`) — no
+compose internals, no `activeRerenderer`/stack, no `siteKey`. So any author can
+build a self-managing frame the same way: `extends HTMLElement` + `Map<key,
+rerenderer(view)>` + imperative DOM ops + idempotent `define`. KeyedList is a
+worked *example* of the pattern, not a maya-internal capability — which
+validates that the public rerenderer is a sufficient primitive for frames.
 
 **Referential transparency confirmed.** Holding the element as a JS ref and
 composing it via `{list}` is referentially transparent — the same element flows
@@ -166,15 +178,24 @@ this.addEventListener('pet:adopted', e => this.update(e.detail.id, {status:'adop
 
 ### Ops (verbs)
 
-`add(...items)` (variadic, append-like, for inline/few) **and** `addAll(items)`
-(an array, the bulk path) · `update(key, data)` · `move(key, beforeKey?)` ·
-`remove(key)` · `clear()` · `has(key)` · `get(key)` · `size` · `keyAt(target)`.
+`add(...items)` (variadic append) · `addAll(items)` (array, bulk) ·
+`insert(data, beforeKey?)` (one row, positional) · `update(key, data)` ·
+`move(key, beforeKey?)` · `remove(key)` · `clear()` · `has(key)` · `get(key)` ·
+`keyFor(node)` · `size` · `[Symbol.iterator]` → `[key, node]`.
 
-**`move` is key-relative** — `move(key, beforeKey)` puts the row before
-`beforeKey`'s row; omit `beforeKey` → to the end (mirrors DOM `insertBefore`).
-The author works in keys, not indices, so there is no `move(key, index)`.
-**Positional insert = `add` then `move`** — so no `{before}` option (fragile
-against variadic `add`) and no `addBefore`. Subtracted.
+**Placement is key-relative, via a positional `beforeKey` arg** (omit/null → to
+the end; mirrors DOM `insertBefore`):
+- `insert(data, beforeKey)` — add one row at a position. Earns its keep over
+  `add`+`move` because ordered realtime sources deliver placement *with* the
+  add (e.g. Firebase's prev-key events), and it's one DOM op, not two.
+- `move(key, beforeKey)` — reposition an existing row.
+
+The author works in **keys, not indices** — no `move(key, index)`. And
+`beforeKey` is a plain positional arg, **not** a `{before}` options object
+(which is fragile against variadic `add`) — so no `addBefore` either.
+
+`keyFor(node)` (was `keyAt`) is the delegation path and the inverse of `get`:
+`get(key)→node`, `keyFor(node)→key`.
 
 Why both `add` and `addAll`, not variadic-only (`add(...all)` mirroring
 `element.append`): a list is the **big-N** case — `add(...10_000)` risks

--- a/docs/design/keyed-list.md
+++ b/docs/design/keyed-list.md
@@ -33,6 +33,19 @@ Two sides of one pattern, distinguished at the composition seam **by casing**
 
 The author reads the render flow from the spelling. That's the payoff of Q1.
 
+**When you need the frame (custom element) vs not (UIComponent).** A UIComponent
+(JS-flow, runs-once-returns-rerenderable) covers two jobs — **tactical DOM-
+manipulation encapsulation** and **compositional work** — and *neither needs a
+new frame*; both live inside the page's forward-only render. Reach for a custom
+element only when the work is **dynamic and self-managing** (add/remove/move/
+update over time) — the case that falls outside forward-only and earns its own
+cycle. KeyedList is that case; most encapsulation/composition is not.
+
+**Referential transparency confirmed.** Holding the element as a JS ref and
+composing it via `{list}` is referentially transparent — the same element flows
+through, re-renders don't replace it (compose's `===` anchor memo no-ops), rows
+survive. azoth owns the JSX call-site, so this is tested, not assumed.
+
 ## Renderer reset (the frame boundary, expressed in code)
 
 The conceptual frame boundary has a 1:1 expression in `renderer.js`. Today the
@@ -154,8 +167,14 @@ this.addEventListener('pet:adopted', e => this.update(e.detail.id, {status:'adop
 ### Ops (verbs)
 
 `add(...items)` (variadic, append-like, for inline/few) **and** `addAll(items)`
-(an array, the bulk path) · `update(key, data)` · `move(key, index)` ·
+(an array, the bulk path) · `update(key, data)` · `move(key, beforeKey?)` ·
 `remove(key)` · `clear()` · `has(key)` · `get(key)` · `size` · `keyAt(target)`.
+
+**`move` is key-relative** — `move(key, beforeKey)` puts the row before
+`beforeKey`'s row; omit `beforeKey` → to the end (mirrors DOM `insertBefore`).
+The author works in keys, not indices, so there is no `move(key, index)`.
+**Positional insert = `add` then `move`** — so no `{before}` option (fragile
+against variadic `add`) and no `addBefore`. Subtracted.
 
 Why both `add` and `addAll`, not variadic-only (`add(...all)` mirroring
 `element.append`): a list is the **big-N** case — `add(...10_000)` risks

--- a/packages/maya/blocks/KeyedList.js
+++ b/packages/maya/blocks/KeyedList.js
@@ -41,6 +41,10 @@ export class KeyedList extends HTMLElement {
 
     get root() { return this.#root ??= this.createRoot(); }
 
+    // Where rows are appended. Default: the root itself. Leaves whose semantic
+    // root nests the rows override it (KeyedTable → the <tbody>).
+    get rowContainer() { return this.root; }
+
     connectedCallback() {
         const root = this.root; // builds it on first connect
         // Attach the created root once (idempotent — connectedCallback can
@@ -55,7 +59,7 @@ export class KeyedList extends HTMLElement {
         const key = this.key(data);
         const render = rerenderer(this.view); // one rerenderer instance per row
         const node = render(data);            // first call: builds + caches the node
-        this.root.append(node);
+        this.rowContainer.append(node);
         this.#rows.set(key, { node, render });
         this.#keys.set(node, key);
         return node;
@@ -77,10 +81,14 @@ export class KeyedList extends HTMLElement {
         this.#rows.delete(key);
     }
 
+    // Reorder so the row ends up at `index` in the final order. Index-based
+    // (vs add's {before:key} — the index-vs-key consistency call is still open).
     move(key, index) {
         const row = this.#rows.get(key);
         if(!row) return;
-        this.root.insertBefore(row.node, this.root.children[index] ?? null);
+        const container = this.rowContainer;
+        const others = [...container.children].filter(n => n !== row.node);
+        container.insertBefore(row.node, others[index] ?? null);
     }
 
     clear() {

--- a/packages/maya/blocks/KeyedList.js
+++ b/packages/maya/blocks/KeyedList.js
@@ -1,0 +1,109 @@
+import { rerenderer } from '../renderer/rerenderer.js';
+
+/**
+ * KeyedList — the dynamic-list specialty: add / remove / move / update over
+ * keyed rows, each change keeping its delta (no reconcile-by-diff).
+ *
+ * A PURE-PLATFORM custom element (hyphenated tag, the platform upgrades it).
+ * The element is a new render frame out of the page's forward-only flow:
+ * `connectedCallback` builds the semantic root; the ops are imperative.
+ *
+ * Per-row identity is a JS Map, not a DOM query: `Map<key, { node, render }>`.
+ * Each row holds its OWN rerenderer instance (built from the shared `view`),
+ * so `update(key, data)` re-runs that row and rebinds its node IN PLACE — the
+ * same `view`/site can't collide across rows because the rerenderer cache is
+ * per-instance.
+ *
+ * Abstract base — NO tag, NO define; the extend target. Concrete leaves
+ * (KeyedUList/KeyedOList/KeyedTable) fix the semantic root and self-define.
+ * See docs/design/keyed-list.md.
+ *
+ * Subclass hooks (function-valued props, set in the subclass constructor):
+ *   key  — data => identity
+ *   view — data => DOM   (the row's rerenderable thunk)
+ */
+export class KeyedList extends HTMLElement {
+    // key -> { node, render } — location/update/remove are O(1), no DOM query.
+    #rows = new Map();
+    // rowNode -> key — the one DOM→key path, for event delegation (keyAt).
+    #keys = new WeakMap();
+    // the semantic container the rows live in (memoized from createRoot()).
+    #root = null;
+
+    /** @type {(data: any) => any} derives a row's identity. */
+    key;
+    /** @type {(data: any) => Node} the row's rerenderable thunk. */
+    view;
+
+    // The semantic container. Base: the element itself (raw, no wrapper).
+    // Leaves override (KeyedUList → <ul>, KeyedTable → <table><tbody>, …).
+    createRoot() { return this; }
+
+    get root() { return this.#root ??= this.createRoot(); }
+
+    connectedCallback() {
+        const root = this.root; // builds it on first connect
+        // Attach the created root once (idempotent — connectedCallback can
+        // fire on every insertion). Base's root IS the element: nothing to do.
+        if(root !== this && root.parentNode !== this) this.append(root);
+    }
+
+    add(...items) { for(const item of items) this.#insert(item); }
+    addAll(items) { for(const item of items) this.#insert(item); }
+
+    #insert(data) {
+        const key = this.key(data);
+        const render = rerenderer(this.view); // one rerenderer instance per row
+        const node = render(data);            // first call: builds + caches the node
+        this.root.append(node);
+        this.#rows.set(key, { node, render });
+        this.#keys.set(node, key);
+        return node;
+    }
+
+    // Re-run that row's rerenderer: same node, rebound with new data (in place).
+    update(key, data) {
+        const row = this.#rows.get(key);
+        if(!row) return null;
+        row.render(data);
+        return row.node;
+    }
+
+    remove(key) {
+        const row = this.#rows.get(key);
+        if(!row) return;
+        this.#keys.delete(row.node);
+        row.node.remove();
+        this.#rows.delete(key);
+    }
+
+    move(key, index) {
+        const row = this.#rows.get(key);
+        if(!row) return;
+        this.root.insertBefore(row.node, this.root.children[index] ?? null);
+    }
+
+    clear() {
+        for(const { node } of this.#rows.values()) {
+            this.#keys.delete(node);
+            node.remove();
+        }
+        this.#rows.clear();
+    }
+
+    has(key) { return this.#rows.has(key); }
+    get(key) { return this.#rows.get(key)?.node ?? null; }
+    get size() { return this.#rows.size; }
+
+    // Delegation: given an event target, the key of the row it's inside.
+    keyAt(target) {
+        for(let n = target; n && n !== this; n = n.parentNode) {
+            if(this.#keys.has(n)) return this.#keys.get(n);
+        }
+        return undefined;
+    }
+
+    *[Symbol.iterator]() {
+        for(const [key, { node }] of this.#rows) yield [key, node];
+    }
+}

--- a/packages/maya/blocks/KeyedList.js
+++ b/packages/maya/blocks/KeyedList.js
@@ -81,14 +81,14 @@ export class KeyedList extends HTMLElement {
         this.#rows.delete(key);
     }
 
-    // Reorder so the row ends up at `index` in the final order. Index-based
-    // (vs add's {before:key} — the index-vs-key consistency call is still open).
-    move(key, index) {
+    // Move the row to before `beforeKey`'s row; omit/null → to the end.
+    // Key-relative (the author works in keys, not indices), mirrors DOM
+    // insertBefore. Positional insert = add then move.
+    move(key, beforeKey) {
         const row = this.#rows.get(key);
         if(!row) return;
-        const container = this.rowContainer;
-        const others = [...container.children].filter(n => n !== row.node);
-        container.insertBefore(row.node, others[index] ?? null);
+        const ref = beforeKey == null ? null : (this.#rows.get(beforeKey)?.node ?? null);
+        this.rowContainer.insertBefore(row.node, ref);
     }
 
     clear() {

--- a/packages/maya/blocks/KeyedList.js
+++ b/packages/maya/blocks/KeyedList.js
@@ -52,14 +52,19 @@ export class KeyedList extends HTMLElement {
         if(root !== this && root.parentNode !== this) this.append(root);
     }
 
-    add(...items) { for(const item of items) this.#insert(item); }
-    addAll(items) { for(const item of items) this.#insert(item); }
+    add(...items) { for(const item of items) this.#place(item, null); }
+    addAll(items) { for(const item of items) this.#place(item, null); }
 
-    #insert(data) {
+    // Insert one row before `beforeKey`'s row; omit/null → append. For sources
+    // that carry placement with the item (e.g. Firebase's prev-key add events).
+    insert(data, beforeKey) { return this.#place(data, beforeKey); }
+
+    #place(data, beforeKey) {
         const key = this.key(data);
         const render = rerenderer(this.view); // one rerenderer instance per row
         const node = render(data);            // first call: builds + caches the node
-        this.rowContainer.append(node);
+        const ref = beforeKey == null ? null : (this.#rows.get(beforeKey)?.node ?? null);
+        this.rowContainer.insertBefore(node, ref); // null ref → append
         this.#rows.set(key, { node, render });
         this.#keys.set(node, key);
         return node;
@@ -83,7 +88,7 @@ export class KeyedList extends HTMLElement {
 
     // Move the row to before `beforeKey`'s row; omit/null → to the end.
     // Key-relative (the author works in keys, not indices), mirrors DOM
-    // insertBefore. Positional insert = add then move.
+    // insertBefore. (Positional add is insert().)
     move(key, beforeKey) {
         const row = this.#rows.get(key);
         if(!row) return;
@@ -103,8 +108,9 @@ export class KeyedList extends HTMLElement {
     get(key) { return this.#rows.get(key)?.node ?? null; }
     get size() { return this.#rows.size; }
 
-    // Delegation: given an event target, the key of the row it's inside.
-    keyAt(target) {
+    // The key for an event target's row (walks up to the row root). Inverse of
+    // get(key): get is key→node, keyFor is node→key. The delegation path.
+    keyFor(target) {
         for(let n = target; n && n !== this; n = n.parentNode) {
             if(this.#keys.has(n)) return this.#keys.get(n);
         }

--- a/packages/maya/blocks/KeyedOList.js
+++ b/packages/maya/blocks/KeyedOList.js
@@ -1,0 +1,11 @@
+import { KeyedList } from './KeyedList.js';
+
+/**
+ * KeyedOList — the `<ol>` keyed-list leaf. Owns a real `<ol>`; the author's
+ * `view` returns the `<li>`. Self-defines `<keyed-ol>` idempotently.
+ */
+export class KeyedOList extends KeyedList {
+    createRoot() { return document.createElement('ol'); }
+}
+
+if(!customElements.get('keyed-ol')) customElements.define('keyed-ol', KeyedOList);

--- a/packages/maya/blocks/KeyedTable.js
+++ b/packages/maya/blocks/KeyedTable.js
@@ -1,0 +1,21 @@
+import { KeyedList } from './KeyedList.js';
+
+/**
+ * KeyedTable — the `<table>` keyed-list leaf. Owns a real `<table><tbody>` and
+ * manages `<tr>` rows in the tbody; the author's `view` returns the `<tr>`.
+ *
+ * This is why the base separates `root` (appended to the element) from
+ * `rowContainer` (where rows go): here root is the `<table>`, rowContainer the
+ * nested `<tbody>`. Self-defines `<keyed-table>` idempotently.
+ */
+export class KeyedTable extends KeyedList {
+    createRoot() {
+        const table = document.createElement('table');
+        table.append(document.createElement('tbody'));
+        return table;
+    }
+
+    get rowContainer() { return this.root.querySelector('tbody'); }
+}
+
+if(!customElements.get('keyed-table')) customElements.define('keyed-table', KeyedTable);

--- a/packages/maya/blocks/KeyedUList.js
+++ b/packages/maya/blocks/KeyedUList.js
@@ -1,0 +1,14 @@
+import { KeyedList } from './KeyedList.js';
+
+/**
+ * KeyedUList — the `<ul>` keyed-list leaf. Owns a real `<ul>` (light DOM) and
+ * manages `<li>` rows inside it; the author's `view` returns the `<li>`.
+ *
+ * Self-defines `<keyed-ul>` idempotently on import (a double-load can't throw).
+ * Author subclasses extend this and define their own tag.
+ */
+export class KeyedUList extends KeyedList {
+    createRoot() { return document.createElement('ul'); }
+}
+
+if(!customElements.get('keyed-ul')) customElements.define('keyed-ul', KeyedUList);

--- a/packages/maya/blocks/blocks.js
+++ b/packages/maya/blocks/blocks.js
@@ -2,3 +2,5 @@ export * from './KeyedBlock.js';
 export * from './Toggle.js';
 export * from './KeyedList.js';
 export * from './KeyedUList.js';
+export * from './KeyedOList.js';
+export * from './KeyedTable.js';

--- a/packages/maya/blocks/blocks.js
+++ b/packages/maya/blocks/blocks.js
@@ -1,2 +1,4 @@
 export * from './KeyedBlock.js';
 export * from './Toggle.js';
+export * from './KeyedList.js';
+export * from './KeyedUList.js';

--- a/packages/valhalla/keyed-list.test.tsx
+++ b/packages/valhalla/keyed-list.test.tsx
@@ -64,3 +64,59 @@ describe('KeyedUList — authoring', () => {
     });
 
 });
+
+describe('KeyedUList — ops', () => {
+
+    const make = () => {
+        const list = document.createElement('pet-list') as PetList;
+        document.body.append(list);
+        return list;
+    };
+    const order = (list: PetList) => [...list.root.children].map(n => n.textContent);
+
+    test('add — variadic: one, several, or spread (each arg is a row)', ({ expect }) => {
+        const list = make();
+        list.add({ id: 1, name: 'Felix' });
+        list.add({ id: 2, name: 'Mittens' }, { id: 3, name: 'Tom' });
+        list.add(...[{ id: 4, name: 'Ada' }]);
+        expect(list.size).toBe(4);
+        expect(order(list)).toEqual(['Felix', 'Mittens', 'Tom', 'Ada']);
+    });
+
+    test('remove — drops the row, its node, and its key', ({ expect }) => {
+        const list = make();
+        list.addAll([{ id: 1, name: 'Felix' }, { id: 2, name: 'Mittens' }, { id: 3, name: 'Tom' }]);
+        list.remove(2);
+        expect(list.size).toBe(2);
+        expect(list.has(2)).toBe(false);
+        expect(list.get(2)).toBe(null);
+        expect(order(list)).toEqual(['Felix', 'Tom']);
+    });
+
+    test('move — the row ends up at the given index (forward and back)', ({ expect }) => {
+        const list = make();
+        list.addAll([{ id: 1, name: 'Felix' }, { id: 2, name: 'Mittens' }, { id: 3, name: 'Tom' }]);
+        list.move(3, 0);                              // to front
+        expect(order(list)).toEqual(['Tom', 'Felix', 'Mittens']);
+        list.move(3, 2);                              // forward, to end
+        expect(order(list)).toEqual(['Felix', 'Mittens', 'Tom']);
+    });
+
+    test('clear — empties the DOM and the key map', ({ expect }) => {
+        const list = make();
+        list.addAll([{ id: 1, name: 'Felix' }, { id: 2, name: 'Mittens' }]);
+        list.clear();
+        expect(list.size).toBe(0);
+        expect(order(list)).toEqual([]);
+    });
+
+    test('keyAt — event target → its row key, walking up to the row root', ({ expect }) => {
+        const list = make();
+        list.addAll([{ id: 1, name: 'Felix' }, { id: 2, name: 'Mittens' }]);
+        const li = list.get(1)!;
+        expect(list.keyAt(li)).toBe(1);               // the row root itself
+        expect(list.keyAt(li.firstChild!)).toBe(1);   // a descendant (the text node)
+        expect(list.keyAt(list)).toBe(undefined);     // outside any row
+    });
+
+});

--- a/packages/valhalla/keyed-list.test.tsx
+++ b/packages/valhalla/keyed-list.test.tsx
@@ -111,13 +111,23 @@ describe('KeyedUList — ops', () => {
         expect(order(list)).toEqual([]);
     });
 
-    test('keyAt — event target → its row key, walking up to the row root', ({ expect }) => {
+    test('insert — place one row before another (positional add); null → append', ({ expect }) => {
+        const list = make();
+        list.addAll([{ id: 1, name: 'Felix' }, { id: 2, name: 'Mittens' }]);
+        list.insert({ id: 3, name: 'Tom' }, 2);       // before Mittens
+        expect(order(list)).toEqual(['Felix', 'Tom', 'Mittens']);
+        list.insert({ id: 4, name: 'Ada' }, null);    // no beforeKey → append
+        expect(order(list)).toEqual(['Felix', 'Tom', 'Mittens', 'Ada']);
+        expect(list.size).toBe(4);
+    });
+
+    test('keyFor — event target → its row key (inverse of get), walking to the row root', ({ expect }) => {
         const list = make();
         list.addAll([{ id: 1, name: 'Felix' }, { id: 2, name: 'Mittens' }]);
         const li = list.get(1)!;
-        expect(list.keyAt(li)).toBe(1);               // the row root itself
-        expect(list.keyAt(li.firstChild!)).toBe(1);   // a descendant (the text node)
-        expect(list.keyAt(list)).toBe(undefined);     // outside any row
+        expect(list.keyFor(li)).toBe(1);              // the row root itself
+        expect(list.keyFor(li.firstChild!)).toBe(1);  // a descendant (the text node)
+        expect(list.keyFor(list)).toBe(undefined);    // outside any row
     });
 
 });

--- a/packages/valhalla/keyed-list.test.tsx
+++ b/packages/valhalla/keyed-list.test.tsx
@@ -191,3 +191,57 @@ describe('KeyedUList — nested inside a rerenderer (the frame boundary)', () =>
     });
 
 });
+
+describe('Controller — the source axis (author-defined bridge)', () => {
+
+    // A controller bridges a data SOURCE to LIST OPS. azoth ships none — this is
+    // the contract/recipe an author (or a per-source library) implements. The
+    // source's delta maps straight to an op; no reconcile-by-diff.
+    //
+    // Stub source: an EventTarget standing in for supabase realtime / a
+    // websocket feed (mocks are fine for controllers).
+    class FeedStub extends EventTarget {
+        insert(pet: { id: number; name: string }) { this.dispatchEvent(new CustomEvent('insert', { detail: pet })); }
+        update(pet: { id: number; name: string }) { this.dispatchEvent(new CustomEvent('update', { detail: pet })); }
+        remove(id: number) { this.dispatchEvent(new CustomEvent('remove', { detail: id })); }
+    }
+
+    class FeedController {
+        constructor(public source: FeedStub, list: PetList) {
+            this.#on('insert', e => list.add(e.detail));
+            this.#on('update', e => list.update(e.detail.id, e.detail));
+            this.#on('remove', e => list.remove(e.detail));
+        }
+        #offs: Array<() => void> = [];
+        #on(type: string, fn: (e: any) => void) {
+            this.source.addEventListener(type, fn);
+            this.#offs.push(() => this.source.removeEventListener(type, fn));
+        }
+        dispose() { this.#offs.forEach(off => off()); }   // pairs to disconnectedCallback
+    }
+
+    test('source events drive add / update (in place) / remove; dispose tears down', ({ expect }) => {
+        const feed = new FeedStub();
+        const list = document.createElement('pet-list') as PetList;
+        document.body.append(list);
+        const ctl = new FeedController(feed, list);
+
+        feed.insert({ id: 1, name: 'Felix' });
+        feed.insert({ id: 2, name: 'Mittens' });
+        expect([...list.root.children].map(n => n.textContent)).toEqual(['Felix', 'Mittens']);
+
+        const li1 = list.get(1);
+        feed.update({ id: 1, name: 'Felicia' });
+        expect(list.get(1)).toBe(li1);                    // delta → update(key): same node, in place
+        expect(li1!.textContent).toBe('Felicia');
+
+        feed.remove(2);
+        expect(list.has(2)).toBe(false);
+        expect([...list.root.children].map(n => n.textContent)).toEqual(['Felicia']);
+
+        ctl.dispose();
+        feed.insert({ id: 3, name: 'Tom' });              // after teardown: no effect
+        expect(list.has(3)).toBe(false);
+    });
+
+});

--- a/packages/valhalla/keyed-list.test.tsx
+++ b/packages/valhalla/keyed-list.test.tsx
@@ -1,0 +1,66 @@
+/// <reference types="vitest" />
+/// <reference path="../azoth/jsx.d.ts" />
+/**
+ * KEYED LIST — AUTHORING (author-first)
+ *
+ * This file is written author-first: it is the code we want an author to
+ * write, and it drives the implementation. RED until KeyedUList lands.
+ *
+ * The stance (see docs/design/keyed-list.md):
+ *  - A keyed list is a PURE-PLATFORM custom element — hyphenated tag, the
+ *    platform upgrades it, a new render frame out of the forward-only flow.
+ *  - Authoring is class-based: extend the semantic leaf (KeyedUList →
+ *    <ul>/<li>), define `key` and `view` as FUNCTION-VALUED PROPS (the
+ *    rerenderer thunks) in the constructor (runs once; connected/disconnected
+ *    cycle through).
+ *  - The ops keep the delta: add / addAll / update / move / remove — no
+ *    reconcile-by-diff. `update(key, data)` rebinds that row's node IN PLACE
+ *    (its own per-row rerenderer — the Q3 contract this file also covers).
+ *
+ * Provisional: module home (`@azothjs/maya/blocks`) and the JSX form
+ * `<pet-list/>` (needs an IntrinsicElements declaration — the next
+ * author-first constraint) are TBD. This file creates via
+ * document.createElement to isolate the authoring stance from JSX typing.
+ *
+ * JSX kept inline (single-line) so snapshots don't pick up whitespace nodes.
+ * Expected HTML was generated via `toMatchInlineSnapshot` + `-u`, then frozen
+ * to `.toBe(...)` — the `-u` updater coalesces multiple snapshots per file
+ * (unfixed in vitest 4.x; see CLAUDE.md).
+ */
+import { describe, test } from 'vitest';
+import { KeyedUList } from '@azothjs/maya/blocks';
+
+type Pet = { id: number; name: string };
+
+class PetList extends KeyedUList {
+    constructor() {
+        super();
+        this.key  = (p: Pet) => p.id;                 // identity (setup, runs once)
+        this.view = (p: Pet) => <li>{p.name}</li>;    // the row's rerenderable thunk
+    }
+}
+if(!customElements.get('pet-list')) customElements.define('pet-list', PetList);
+
+describe('KeyedUList — authoring', () => {
+
+    test('subclass renders keyed rows into its own <ul>', ({ expect }) => {
+        const list = document.createElement('pet-list') as PetList;
+        document.body.append(list);                   // connect → builds the <ul>
+        list.addAll([{ id: 1, name: 'Felix' }, { id: 2, name: 'Mittens' }]);
+        expect(list.outerHTML).toBe('<pet-list><ul><li>Felix<!--1--></li><li>Mittens<!--1--></li></ul></pet-list>');
+    });
+
+    test('update(key, data) rebinds that row IN PLACE — same node, new value', ({ expect }) => {
+        const list = document.createElement('pet-list') as PetList;
+        document.body.append(list);
+        list.addAll([{ id: 1, name: 'Felix' }, { id: 2, name: 'Mittens' }]);
+
+        const before = list.get(1);                   // the <li> for key 1
+        list.update(1, { id: 1, name: 'Felicia' });
+        const after = list.get(1);
+
+        expect(after).toBe(before);                   // per-row rerenderer: same node
+        expect(list.outerHTML).toBe('<pet-list><ul><li>Felicia<!--1--></li><li>Mittens<!--1--></li></ul></pet-list>');
+    });
+
+});

--- a/packages/valhalla/keyed-list.test.tsx
+++ b/packages/valhalla/keyed-list.test.tsx
@@ -29,6 +29,7 @@
  */
 import { describe, test } from 'vitest';
 import { KeyedUList } from '@azothjs/maya/blocks';
+import { rerenderer } from '@azothjs/maya/renderer';
 
 type Pet = { id: number; name: string };
 
@@ -117,6 +118,32 @@ describe('KeyedUList — ops', () => {
         expect(list.keyAt(li)).toBe(1);               // the row root itself
         expect(list.keyAt(li.firstChild!)).toBe(1);   // a descendant (the text node)
         expect(list.keyAt(list)).toBe(undefined);     // outside any row
+    });
+
+});
+
+describe('KeyedUList — nested inside a rerenderer (the frame boundary)', () => {
+
+    // A keyed list lives inside a re-rendering region. The custom element is a
+    // separate render frame: the outer rerenderer reuses the element by site
+    // and never reaches into its internals, so its imperatively-managed rows
+    // survive an outer re-render. (If this holds, the fresh-Renderer-frame
+    // reset is moot — see docs/design/keyed-list.md.)
+    test('outer re-render reuses the element; its rows survive', ({ expect }) => {
+        const render = rerenderer((label: string) =>
+            <section><h2>{label}</h2><pet-list></pet-list></section>);
+
+        const section = render('Pets') as HTMLElement;
+        document.body.append(section);                // connect → pet-list builds its <ul>
+        const list = section.querySelector('pet-list') as PetList;
+        list.addAll([{ id: 1, name: 'Felix' }, { id: 2, name: 'Mittens' }]);
+        expect([...list.root.children].map(n => n.textContent)).toEqual(['Felix', 'Mittens']);
+
+        const again = render('Animals');              // outer rerenderer re-runs
+        expect(again).toBe(section);                  // same section (site cache)
+        expect(section.querySelector('pet-list')).toBe(list);            // element reused, not rebuilt
+        expect(section.querySelector('h2')!.textContent).toBe('Animals'); // outer binding rebound
+        expect([...list.root.children].map(n => n.textContent)).toEqual(['Felix', 'Mittens']); // rows intact
     });
 
 });

--- a/packages/valhalla/keyed-list.test.tsx
+++ b/packages/valhalla/keyed-list.test.tsx
@@ -28,7 +28,7 @@
  * (unfixed in vitest 4.x; see CLAUDE.md).
  */
 import { describe, test } from 'vitest';
-import { KeyedUList } from '@azothjs/maya/blocks';
+import { KeyedUList, KeyedOList, KeyedTable } from '@azothjs/maya/blocks';
 import { rerenderer } from '@azothjs/maya/renderer';
 
 type Pet = { id: number; name: string };
@@ -118,6 +118,50 @@ describe('KeyedUList — ops', () => {
         expect(list.keyAt(li)).toBe(1);               // the row root itself
         expect(list.keyAt(li.firstChild!)).toBe(1);   // a descendant (the text node)
         expect(list.keyAt(list)).toBe(undefined);     // outside any row
+    });
+
+});
+
+describe('KeyedOList / KeyedTable — semantic leaves', () => {
+
+    test('KeyedOList owns an <ol> and manages <li> rows', ({ expect }) => {
+        class NumList extends KeyedOList {
+            constructor() {
+                super();
+                this.key = (n: { id: number; label: string }) => n.id;
+                this.view = (n: { id: number; label: string }) => <li>{n.label}</li>;
+            }
+        }
+        if(!customElements.get('num-list')) customElements.define('num-list', NumList);
+
+        const list = document.createElement('num-list') as KeyedOList;
+        document.body.append(list);
+        list.addAll([{ id: 1, label: 'one' }, { id: 2, label: 'two' }]);
+
+        const ol = list.querySelector('ol')!;
+        expect([...ol.children].map(li => li.tagName)).toEqual(['LI', 'LI']);
+        expect([...ol.children].map(li => li.textContent)).toEqual(['one', 'two']);
+    });
+
+    test('KeyedTable owns <table><tbody> and manages <tr> rows in the tbody', ({ expect }) => {
+        class RowList extends KeyedTable {
+            constructor() {
+                super();
+                this.key = (r: { id: number; name: string }) => r.id;
+                this.view = (r: { id: number; name: string }) => <tr><td>{r.name}</td></tr>;
+            }
+        }
+        if(!customElements.get('row-list')) customElements.define('row-list', RowList);
+
+        const list = document.createElement('row-list') as KeyedTable;
+        document.body.append(list);
+        list.addAll([{ id: 1, name: 'Felix' }, { id: 2, name: 'Mittens' }]);
+
+        const tbody = list.querySelector('table > tbody')!;
+        expect([...tbody.children].map(tr => tr.tagName)).toEqual(['TR', 'TR']);
+        expect([...tbody.querySelectorAll('td')].map(td => td.textContent)).toEqual(['Felix', 'Mittens']);
+        expect(list.update(1, { id: 1, name: 'Felicia' })).toBe(tbody.children[0]); // in-place, same <tr>
+        expect(tbody.querySelector('td')!.textContent).toBe('Felicia');
     });
 
 });

--- a/packages/valhalla/keyed-list.test.tsx
+++ b/packages/valhalla/keyed-list.test.tsx
@@ -94,13 +94,13 @@ describe('KeyedUList — ops', () => {
         expect(order(list)).toEqual(['Felix', 'Tom']);
     });
 
-    test('move — the row ends up at the given index (forward and back)', ({ expect }) => {
+    test('move — key-relative: before another row, or to the end', ({ expect }) => {
         const list = make();
         list.addAll([{ id: 1, name: 'Felix' }, { id: 2, name: 'Mittens' }, { id: 3, name: 'Tom' }]);
-        list.move(3, 0);                              // to front
+        list.move(3, 1);                              // Tom before Felix
         expect(order(list)).toEqual(['Tom', 'Felix', 'Mittens']);
-        list.move(3, 2);                              // forward, to end
-        expect(order(list)).toEqual(['Felix', 'Mittens', 'Tom']);
+        list.move(1, null);                           // Felix to the end (no beforeKey)
+        expect(order(list)).toEqual(['Tom', 'Mittens', 'Felix']);
     });
 
     test('clear — empties the DOM and the key map', ({ expect }) => {
@@ -187,6 +187,26 @@ describe('KeyedUList — nested inside a rerenderer (the frame boundary)', () =>
         expect(again).toBe(section);                  // same section (site cache)
         expect(section.querySelector('pet-list')).toBe(list);            // element reused, not rebuilt
         expect(section.querySelector('h2')!.textContent).toBe('Animals'); // outer binding rebound
+        expect([...list.root.children].map(n => n.textContent)).toEqual(['Felix', 'Mittens']); // rows intact
+    });
+
+    // Stronger: hold the element as a JS ref and compose it via {list}. azoth
+    // owns the JSX call-site, so confirm it's referentially transparent — the
+    // same element flows through, re-renders don't replace it, rows survive.
+    test('an externally-held element ref composed via {list} stays the same element', ({ expect }) => {
+        const list = <pet-list></pet-list> as PetList;     // created once, held
+        const render = rerenderer((label: string) =>
+            <section><h2>{label}</h2>{list}</section>);
+
+        const section = render('Pets') as HTMLElement;
+        document.body.append(section);                     // connect → builds the <ul>
+        expect(section.querySelector('pet-list')).toBe(list);   // the very ref, composed in
+        list.addAll([{ id: 1, name: 'Felix' }, { id: 2, name: 'Mittens' }]);
+
+        const again = render('Animals');                   // {list} is the same ref → no-op at the anchor
+        expect(again).toBe(section);
+        expect(section.querySelector('pet-list')).toBe(list);              // still the same element
+        expect(section.querySelector('h2')!.textContent).toBe('Animals');  // sibling binding rebound
         expect([...list.root.children].map(n => n.textContent)).toEqual(['Felix', 'Mittens']); // rows intact
     });
 

--- a/packages/valhalla/rerenderer.test.tsx
+++ b/packages/valhalla/rerenderer.test.tsx
@@ -142,9 +142,14 @@ describe('rerenderer — JSX-driven', () => {
         // calls, and one suffices here. Nothing azoth-specific to learn;
         // subtract to unlock.
         let setupCount = 0;
-        function CatCard({ count = 0 }: { count?: number }) {
+        // The cast is the known typing gap: a component returning its
+        // rerenderable (a function) isn't yet modeled by JSX.Element — the
+        // same `as unknown as JSX.Element` workaround as channels.test.tsx.
+        // The TypeScript review (TODO §Components) is where this gets typed.
+        function CatCard({ count = 0 }: { count?: number; id: number }) {
             setupCount++; // setup zone — runs ONCE
-            return ({ id }: { id: number }) => <p>cat #{id} rendered {++count} times</p>;
+            return (({ id }: { id: number }) =>
+                <p>cat #{id} rendered {++count} times</p>) as unknown as JSX.Element;
         }
         const page = rerenderer((id: number) => <main><CatCard count={5} id={id} /></main>);
 


### PR DESCRIPTION
## KeyedList — pure-platform keyed list (design + first implementation)

The dynamic-list specialty: add/remove/move/update over keyed rows, each change keeping its delta (no reconcile-by-diff). Built as a **pure-platform custom element** — a render frame *out of* the page's forward-only flow.

### Design
- **Hyphenated custom element** (`<keyed-ul>`), platform-upgraded — Q1. The casing marks the render flow at the composition seam: `<PetFilter/>` (JS-flow component) vs `<pet-adoption-dashboard/>` (platform-flow custom element).
- **Two axes, never crossed:** presentation (`KeyedList` abstract base + `KeyedUList`/`KeyedOList`/`KeyedTable` leaves) and source (author-defined controllers, composed in).
- **Per-row rerenderer:** `Map<key, rerenderer(view)>` — each row its own instance, so `update(key, data)` rebinds in place. The same `view` can't collide across rows (per-instance cache).
- Full design + the design-dialogue transcript in `docs/design/keyed-list.md` / `keyed-list-transcript.md`.

### What's here
- `KeyedList` (abstract base, no tag), `KeyedUList`/`KeyedOList`/`KeyedTable` (leaves, idempotent self-define) — `packages/maya/blocks/`.
- Ops: `add(...items)`, `addAll`, `insert(data, beforeKey)`, `update`, `move(key, beforeKey)`, `remove`, `clear`, `has`, `get`, `keyFor`, `size`, iterator. Placement is key-relative (no index, no `{before}` object).
- Author-first tests + worked controller example (source→ops bridge) — `packages/valhalla/keyed-list.test.tsx`. valhalla 70/70, maya 143/143.

### Findings
- **Fresh-Renderer frame subtracted:** a nested-usage test proves an outer rerenderer reuses the element by site and never reaches in — rows survive. The custom-element boundary *is* the frame boundary, structurally; no `activeRenderer` rename needed.
- **The frame is unprivileged:** KeyedList uses only the public `rerenderer` + platform — any author could build a self-managing frame the same way.
- **vitest `-u` coalescing bug recurred** (unfixed in 4.x) — corrected the CLAUDE.md guidance (generate via `toMatchInlineSnapshot`, freeze to `.toBe`).

### Deferred (noted, not blocking)
- JSX custom-element `IntrinsicElements` typing (tests create via `document.createElement`).
- Legacy cleanup: remove `Controller`/`Updater` + injectable path now that KeyedList rides Rerenderer; rename the `blocks` module.
- Dynamic-prop `set source()` update-handling test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UP41t1LLeZbuytzErfEPAG
