### PR TITLE
docs: frames as a deferred primitive stance

### DIFF
--- a/docs/design/frame-primitives.md
+++ b/docs/design/frame-primitives.md
@@ -9,9 +9,15 @@ pattern. **Not a limit — an invitation.**
 
 ## Two questions, kept separate
 
-1. **Is it a frame?** — dynamic + self-managing, *and* **not** reducible to
-   "replay the same data structure over the same templates" (the rerenderer
-   already does array-replay / ordinal reuse — the loops case). Architecture test.
+1. **Is it a frame?** "Dynamic" is too vague — pin it by what is *not* one.
+   **Tactical DOM work** — render initial DOM from a template, then imperatively
+   set a prop or two on those existing nodes — is *not* a frame; it's a
+   UIComponent (template render + a simple imperative update). Nor is anything
+   reducible to **replaying the same data structure over the same templates**
+   (the rerenderer already does that — array-replay / ordinal reuse, the loops
+   case). A frame is for **self-managing structural change over time** that none
+   of those expresses — rows/views appearing, disappearing, reordering on their
+   own clock. Architecture test.
 2. **Should it ship out-of-the-box?** — **ubiquitous + low opinion-cost**
    (settled semantics, few defensible designs). Inclusion test. Most frames pass
    (1) and fail (2) → they're recipes, not core.
@@ -28,7 +34,7 @@ state the frame needs) + imperative DOM ops + idempotent `define`. Public
 |---|---|---|
 | **Keyed list** (KeyedList) | yes | **YES** — universal; list semantics are settled |
 | **Virtualized list** (VirtualList) | yes (different node lifecycle) | likely — big-data is common; planned leaf |
-| **Route outlet** (URL → view swap) | yes | **strongest next case — but evaluate, don't auto-ship.** Ubiquitous, but routing is high-opinion (nested routes, guards, data-loading). If anything, ship the *outlet* frame, leave the routing strategy to the author |
+| **Route outlet** (navigation → view swap) | yes | **strongest next case — but a `subtract` story, not a router (see note).** |
 | Enter/leave **transitions** (coordinate removal with animation) | yes | recipe — common but opinionated; pairs with lists |
 | **Portal / teleport** (managed placement elsewhere) | yes | recipe |
 | Drag-**sortable** | yes | recipe — specialized; pairs with lists |
@@ -36,6 +42,19 @@ state the frame needs) + imperative DOM ops + idempotent `define`. Public
 | Tabs / accordion / **selection** | **no** — forward-only + CSS + a tiny imperative swap (see keyed-list's select discussion) | n/a |
 | **Forms** | **no** — native + forward-only | n/a |
 | Single **async value** | **no** — that's `Channel`'s job | n/a |
+
+## On routing — no general problems, just app-layout decisions
+
+A state-managed / render-tree router treats every navigation the same — or makes
+you opt out with hacks. But the real question is an **app decision, per route**:
+is the rendered view *preserved and reused*, or *recreated*? The frame model
+makes that an explicit author choice — a kept element ref → reused; a fresh
+element → recreated — not a framework default. So azoth ships (at most) the
+**outlet frame** (the seam where a view swaps) and leaves the *routing strategy*
+to the app. There are no general routing problems, just app-layout decisions —
+*subtract to unlock*. (Proving ground: the first real app — a wre-dashboards →
+works-os-frontend shell — features "router as LLM tool use," which exercises
+exactly this.)
 
 ## The stance
 

--- a/docs/design/frame-primitives.md
+++ b/docs/design/frame-primitives.md
@@ -1,0 +1,48 @@
+# Frames as a deferred primitive stance
+
+A custom-element **frame** (a self-managing render cycle out of the forward-only
+flow — see [keyed-list](./keyed-list.md)) is an **unprivileged author pattern**:
+KeyedList rides only the public `rerenderer` + platform, no maya internals. So
+azoth doesn't have to pre-decide its primitive set. What ships out-of-the-box is
+a deliberate, conservative choice; everything else is a documented, replicable
+pattern. **Not a limit — an invitation.**
+
+## Two questions, kept separate
+
+1. **Is it a frame?** — dynamic + self-managing, *and* **not** reducible to
+   "replay the same data structure over the same templates" (the rerenderer
+   already does array-replay / ordinal reuse — the loops case). Architecture test.
+2. **Should it ship out-of-the-box?** — **ubiquitous + low opinion-cost**
+   (settled semantics, few defensible designs). Inclusion test. Most frames pass
+   (1) and fail (2) → they're recipes, not core.
+
+## The frame recipe (what authors replicate)
+
+`extends HTMLElement` + `Map<key, rerenderer(view)>` (or whatever per-instance
+state the frame needs) + imperative DOM ops + idempotent `define`. Public
+`rerenderer` does the per-site DOM reuse; the element owns its cycle.
+
+## Candidate landscape
+
+| Pattern | A frame? | Ship OOTB? |
+|---|---|---|
+| **Keyed list** (KeyedList) | yes | **YES** — universal; list semantics are settled |
+| **Virtualized list** (VirtualList) | yes (different node lifecycle) | likely — big-data is common; planned leaf |
+| **Route outlet** (URL → view swap) | yes | **strongest next case — but evaluate, don't auto-ship.** Ubiquitous, but routing is high-opinion (nested routes, guards, data-loading). If anything, ship the *outlet* frame, leave the routing strategy to the author |
+| Enter/leave **transitions** (coordinate removal with animation) | yes | recipe — common but opinionated; pairs with lists |
+| **Portal / teleport** (managed placement elsewhere) | yes | recipe |
+| Drag-**sortable** | yes | recipe — specialized; pairs with lists |
+| **Infinite scroll** | yes | recipe — related to VirtualList |
+| Tabs / accordion / **selection** | **no** — forward-only + CSS + a tiny imperative swap (see keyed-list's select discussion) | n/a |
+| **Forms** | **no** — native + forward-only | n/a |
+| Single **async value** | **no** — that's `Channel`'s job | n/a |
+
+## The stance
+
+Ship the ubiquitous-low-opinion few (the **list family**). Keep the frame
+pattern first-class and documented so the ecosystem builds the rest. The
+out-of-the-box set stays small (subtract); the pattern stays open (invitation).
+Consistent with *be the ocean* — azoth provides the primitive (the public
+`rerenderer` + the frame recipe); the platform and authors provide the variety.
+The boundary is reviewed as real cases accrue: a pattern earns core status by
+proving ubiquity *and* settled semantics, not by being possible.

--- a/docs/design/keyed-list.md
+++ b/docs/design/keyed-list.md
@@ -51,7 +51,10 @@ compose internals, no `activeRerenderer`/stack, no `siteKey`. So any author can
 build a self-managing frame the same way: `extends HTMLElement` + `Map<key,
 rerenderer(view)>` + imperative DOM ops + idempotent `define`. KeyedList is a
 worked *example* of the pattern, not a maya-internal capability — which
-validates that the public rerenderer is a sufficient primitive for frames.
+validates that the public rerenderer is a sufficient primitive for frames. So
+the OOTB primitive set becomes a deferred, conservative choice (not a limit, an
+invitation): see [frame-primitives](./frame-primitives.md) for the recognition
+test and the candidate landscape.
 
 **Referential transparency confirmed.** Holding the element as a JS ref and
 composing it via `{list}` is referentially transparent — the same element flows


### PR DESCRIPTION
Captures the strategic consequence of the *unprivileged frame* finding from #5: since a custom-element frame rides only the public `rerenderer`, azoth can defer what becomes a core primitive — an invitation, not a limit.

Separates two questions usually conflated:
1. **Is it a frame?** dynamic + self-managing + not data-replay (architecture).
2. **Ship out-of-the-box?** ubiquitous + low opinion-cost (inclusion).

Includes the frame recipe and a candidate landscape: ship the **list family**; **route-outlet** is the strongest next case but high-opinion (evaluate, don't auto-ship); transitions/portal/sortable/infinite-scroll are **recipes**; tabs/forms/single-async are **not frames**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UP41t1LLeZbuytzErfEPAG