### PR TITLE
feat(types): valhalla typechecks maya via allowJs (+ Channel as JSX child)

### DIFF
--- a/packages/azoth/jsx.d.ts
+++ b/packages/azoth/jsx.d.ts
@@ -8,12 +8,17 @@
  * to provide accurate intellisense for Azoth JSX.
  */
 
-// Children can be strings, numbers, nodes, or arrays of these
+import type { Channel } from '@azothjs/maya/channels';
+
+// Children: strings, numbers, nodes, channels (async/composable sources), or
+// arrays of these. (Ideally maya's full Composable type — Channel is the case
+// surfaced so far; broaden as others appear.)
 type DOMChild =
     | string
     | number
     | boolean
     | Node
+    | Channel
     | null
     | undefined
     | DOMChild[];

--- a/packages/valhalla/tsconfig.json
+++ b/packages/valhalla/tsconfig.json
@@ -2,7 +2,9 @@
     "extends": "../../tsconfig.json",
     "compilerOptions": {
         "noImplicitAny": false,
-        "allowImportingTsExtensions": true
+        "allowImportingTsExtensions": true,
+        "allowJs": true,
+        "checkJs": false
     },
     "include": [
         "./**/*.ts",


### PR DESCRIPTION
**Reframes maya→TS: inference does the bulk, no conversion needed.** Turning on `allowJs` (+ `checkJs:false`) in valhalla lets TS read maya's `.js` and infer its class types — members (`addAll`, `get`, …) and the `HTMLElement` base — resolving **all 60** keyed-list type errors with **zero JSDoc**. So the JSDoc/`.ts` work is now *optional precision* (e.g. typing `view`/`key` as functions instead of `any`), layered per-module on demand — not a prerequisite.

Also: `DOMChild` now includes `Channel` (compose accepts channels as children — `<main>{channel}</main>`).

**60 → 1.** The last error is `CatCard` — a component that returns a *rerenderable* (a function), which TS won't accept as a JSX component. Fixing it needs `JSX.ElementType` (and must NOT broaden `JSX.Element`, which would wreck intrinsic returns) — its own focused increment. Runtime 70/70.

Note: this is the *monorepo* typing path. A published maya for external consumers would still want generated `.d.ts` — a separate future packaging step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UP41t1LLeZbuytzErfEPAG