### PR TITLE
docs: package reorg plan (step 3)

### DIFF
--- a/docs/design/package-reorg.md
+++ b/docs/design/package-reorg.md
@@ -40,3 +40,16 @@ your go; the publishing/versioning/repo decisions are yours.
 3. **vite-plugin → thoth** (with the bump).
 4. **dom-info** fold-or-keep.
 5. **jsonic** extraction (you create the repo; I prep the workspace removal).
+
+## Parked: vite-plugin testing (`vite-test`) — rethink
+
+The `vite-test` project (fixture-diff: `out/` vs `expected-out/`) exists to test
+the vite-plugin, but it's brittle. When vite-plugin folds into thoth, rethink how
+the plugin is tested — likely a focused integration test (compile a known input,
+assert the emitted modules) rather than a committed output-diff fixture.
+
+## Env note: pnpm is pinned
+
+The repo pins **pnpm@11.5.2** (lockfile 9.0). A different local pnpm (e.g. 8.x)
+can't read the lock and will drift versions on install — use `corepack pnpm`
+(honors the pin). Worth a one-line contributor note in the README.

--- a/docs/design/package-reorg.md
+++ b/docs/design/package-reorg.md
@@ -1,0 +1,42 @@
+# Package reorg — plan (step 3)
+
+Current packages (8): `azoth` · `maya` · `thoth` · `vite-plugin` · `dom-info` ·
+`chronos` · `jsonic` · `valhalla`.
+
+Target shape (settled earlier):
+- **maya** — runtime.
+- **thoth** — build/compiler (+ vite-plugin, + dom-info as internals).
+- **azoth** — umbrella (the published install: re-exports maya + the vite plugin).
+- **valhalla** — conformance suite (author-JSX → thoth → maya).
+- **chronos** — out. **jsonic** — own `azothjs` org repo.
+
+## Dependency facts (verified)
+
+- `azoth` depends on + re-exports `chronos/generators` (`exports["./chronos/generators"]`), maya, vite-plugin. So azoth is **published v1.4.5 on npm**.
+- `jsonic` — no cross-package consumers (clean to extract).
+- `dom-info` — imported by `thoth/transform/Analyzer.js` (`resolveDynamic`, `resolveStatic`, `isKnownElement`). A real thoth dependency.
+
+## Moves, stakes, sequence
+
+| # | Move | Stakes | Owner |
+|---|---|---|---|
+| 1 | **valhalla reframe** — README/identity: "public-API/conformance (author-JSX→thoth→maya)", not "projects converging" | trivial, no code | solo-safe |
+| 2 | **chronos out** — remove pkg; drop azoth's dep + `./chronos/generators` export | **BREAKING azoth API** → major bump; confirm no consumers of azoth/chronos/generators | **your call** (versioning) |
+| 3 | **jsonic → own org** — standalone; git-filter to preserve history into a new repo | **needs you** to create `azothjs/jsonic`; I can prep removal from this workspace | **you** (repo) |
+| 4 | **dom-info** — keep as thoth's dep, mark internal (not published standalone), OR fold code into thoth (relative import) | folding touches well-tested thoth; keeping-as-dep is minimal | **your call** (fold vs keep) |
+| 5 | **vite-plugin → thoth** — fold into `@azothjs/thoth/vite`; remap azoth's `./vite-plugin` export | **packaging/export change** → coordinate with the bump | **your call** (with #2's bump) |
+
+## Why this needs you, not solo execution
+
+azoth is a **published package**; #2 and #5 change its `exports` → breaking → a
+**major version bump** (your versioning decision). #3 needs an **external repo**
+you create. #4 is a fold-vs-keep judgment. So: I execute the mechanical parts on
+your go; the publishing/versioning/repo decisions are yours.
+
+## Proposed order
+
+1. **valhalla reframe** (trivial, solo) — can do now.
+2. Decide **chronos removal** + the **azoth major bump** (it gates #2, #5).
+3. **vite-plugin → thoth** (with the bump).
+4. **dom-info** fold-or-keep.
+5. **jsonic** extraction (you create the repo; I prep the workspace removal).


### PR DESCRIPTION
Scopes the consolidation (8 packages → maya / thoth / azoth / valhalla; chronos out, jsonic → own org) with verified deps and a sequence.

**Surfaces the decisions that are yours** (azoth is published on npm v1.4.5):
- **chronos removal** + **vite-plugin → thoth** change azoth's `exports` → breaking → **major version bump** (your versioning call).
- **jsonic → own org** needs you to create the external repo.
- **dom-info** — fold into thoth vs keep as an internal dep (judgment).

Only the **valhalla reframe** (a README identity note) is trivially solo-safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UP41t1LLeZbuytzErfEPAG