### PR TITLE
fix(maya): eqeqeq CI lint in KeyedList

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -372,3 +372,9 @@ saveInlineSnapshots. The comment patch does not cover it. Workaround in use:
 `toBe()` with known values, or fill snapshots one at a time. Spike to isolate
 the exact trigger and fold into the upstream fix. Low priority — single-
 snapshot-per-test (the common case) is unaffected.
+
+## ESLint usage review (lower priority)
+
+Revisit how azoth configures ESLint — e.g. `eqeqeq` flagged `== null` (the
+idiomatic null/undefined check); consider the `{ null: "ignore" }` option, and
+audit the ruleset generally. (Surfaced by a CI failure on KeyedList.js, 2026-06.)

--- a/packages/maya/blocks/KeyedList.js
+++ b/packages/maya/blocks/KeyedList.js
@@ -63,7 +63,7 @@ export class KeyedList extends HTMLElement {
         const key = this.key(data);
         const render = rerenderer(this.view); // one rerenderer instance per row
         const node = render(data);            // first call: builds + caches the node
-        const ref = beforeKey == null ? null : (this.#rows.get(beforeKey)?.node ?? null);
+        const ref = this.#rows.get(beforeKey)?.node ?? null; // null/undefined/missing → null = append
         this.rowContainer.insertBefore(node, ref); // null ref → append
         this.#rows.set(key, { node, render });
         this.#keys.set(node, key);
@@ -92,7 +92,7 @@ export class KeyedList extends HTMLElement {
     move(key, beforeKey) {
         const row = this.#rows.get(key);
         if(!row) return;
-        const ref = beforeKey == null ? null : (this.#rows.get(beforeKey)?.node ?? null);
+        const ref = this.#rows.get(beforeKey)?.node ?? null; // null/undefined/missing → null = append
         this.rowContainer.insertBefore(row.node, ref);
     }
 


### PR DESCRIPTION
CI eslint failed on `== null` (eqeqeq). The check was redundant — `#rows.get(beforeKey)?.node ?? null` already yields `null` for null/undefined/missing keys (→ append). So the fix *simplifies*. Also adds a lower-priority TODO to review azoth's ESLint config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UP41t1LLeZbuytzErfEPAG